### PR TITLE
Support tapping ActiveRecord class/instance

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,11 +4,12 @@ on: [push]
 
 jobs:
   test:
-    name: Test on ruby ${{ matrix.ruby_version }}
+    name: Test on ruby ${{ matrix.ruby_version }} and rails ${{ matrix.rails_version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby_version: ['2.4', '2.5', '2.6']
+        rails_version: ['5.2', '6']
+        ruby_version: ['2.5', '2.6']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v1
@@ -16,8 +17,13 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+    - name: Install sqlite
+      run: |
+        sudo apt-get install libsqlite3-dev
 
-    - name: Build and test with Rake
+    - name: Build and test with Rails ${{ matrix.rails_version }}
+      env:
+        RAILS_VERSION: ${{ matrix.rails_version }}
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     tapping_device (0.1.0)
-      activerecord (~> 6.0)
+      activerecord (= 6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -42,7 +42,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    sqlite3 (1.4.1)
+    sqlite3 (1.3.13)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -56,7 +56,7 @@ DEPENDENCIES
   pry
   rake (~> 10.0)
   rspec (~> 3.0)
-  sqlite3
+  sqlite3 (~> 1.3.6)
   tapping_device!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,29 @@ PATH
   remote: .
   specs:
     tapping_device (0.1.0)
+      activerecord (~> 6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (6.0.0)
+      activesupport (= 6.0.0)
+    activerecord (6.0.0)
+      activemodel (= 6.0.0)
+      activesupport (= 6.0.0)
+    activesupport (6.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.1, >= 2.1.8)
     coderay (1.1.2)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
+    i18n (1.7.0)
+      concurrent-ruby (~> 1.0)
     method_source (0.9.2)
+    minitest (5.12.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -26,6 +42,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    sqlite3 (1.4.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    zeitwerk (2.2.0)
 
 PLATFORMS
   ruby
@@ -35,6 +56,7 @@ DEPENDENCIES
   pry
   rake (~> 10.0)
   rspec (~> 3.0)
+  sqlite3
   tapping_device!
 
 BUNDLED WITH

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -12,6 +12,13 @@ module TappingDevice
       track(klass, **options)
     end
 
+    def tap_association_calls!(record, options = {}, &block)
+      raise "argument should be an instance of ActiveRecord::Base" unless record.is_a?(ActiveRecord::Base)
+      options[:condition] = :tap_associations?
+      options[:block] = block
+      track(record, **options)
+    end
+
     def tap_calls_on!(object, options = {}, &block)
       options[:condition] = :tap_on?
       options[:block] = block
@@ -70,6 +77,14 @@ module TappingDevice
 
     def tap_on?(object, parameters)
       parameters[:receiver].object_id == object.object_id
+    end
+
+    def tap_associations?(object, parameters)
+      return false unless tap_on?(object, parameters)
+
+      model_class = object.class
+      associations = model_class.reflections
+      associations.keys.include?(parameters[:method_name].to_s)
     end
 
     def get_tapping_device(object)

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -1,3 +1,5 @@
+require "active_record"
+
 module TappingDevice
   module Trackable
     TAPPING_DEVICE = :@tapping_device
@@ -56,7 +58,14 @@ module TappingDevice
     end
 
     def tap_init?(klass, parameters)
-      parameters[:method_name] == :initialize && parameters[:receiver].is_a?(klass)
+      receiver = parameters[:receiver]
+      method_name = parameters[:method_name]
+
+      if klass.ancestors.include?(ActiveRecord::Base)
+        method_name == :new && receiver.ancestors.include?(klass)
+      else
+        method_name == :initialize && receiver.is_a?(klass)
+      end
     end
 
     def tap_on?(object, parameters)

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -30,6 +30,7 @@ module TappingDevice
     end
 
     alias :tap_init! :tap_initialization_of!
+    alias :tap_assoc! :tap_association_calls!
     alias :tap_on! :tap_calls_on!
     alias :untap! :stop_tapping!
 

--- a/spec/active_record_model_spec.rb
+++ b/spec/active_record_model_spec.rb
@@ -1,12 +1,10 @@
 require "spec_helper"
 require "model"
 
-RSpec.describe Post do
+RSpec.describe "ActiveRecord model spec" do
   include TappingDevice::Trackable
 
-  before do
-    Post.create!(title: "foo", content: "bar")
-  end
+  let!(:post) { Post.create!(title: "foo", content: "bar") }
 
   describe "triggering test" do
     let(:locations) { [] }
@@ -17,7 +15,7 @@ RSpec.describe Post do
       end
     end
 
-    it "triggers tapping when calling new" do
+    it "triggers tapping when calling .new" do
       Post.new; line = __LINE__
 
       expect(locations.first[:path]).to eq(__FILE__)

--- a/spec/active_record_model_spec.rb
+++ b/spec/active_record_model_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe "ActiveRecord model spec" do
   include TappingDevice::Trackable
 
   let!(:post) { Post.create!(title: "foo", content: "bar") }
+  let(:locations) { [] }
 
-  describe "triggering test" do
+  describe "#tap_init!" do
     let(:locations) { [] }
 
     before do
@@ -20,6 +21,28 @@ RSpec.describe "ActiveRecord model spec" do
 
       expect(locations.first[:path]).to eq(__FILE__)
       expect(locations.first[:line_number]).to eq(line.to_s)
+    end
+  end
+
+  describe "#tap_association_calls!" do
+    let(:user) { User.create!(name: "Stan") }
+    let(:post) { Post.create!(title: "foo", content: "bar", user: user) }
+    let!(:comment) { Comment.create!(post: post, user: user, content: "Nice post!") }
+
+    it "tracks every association calls" do
+      tap_association_calls!(post) do |payload|
+        locations << {path: payload[:filepath], line_number: payload[:line_number]}
+      end
+
+      post.user; line_1 = __LINE__
+      post.title
+      post.comments; line_2 = __LINE__
+
+      expect(locations.count).to eq(2)
+      expect(locations[0][:path]).to eq(__FILE__)
+      expect(locations[0][:line_number]).to eq(line_1.to_s)
+      expect(locations[1][:path]).to eq(__FILE__)
+      expect(locations[1][:line_number]).to eq(line_2.to_s)
     end
   end
 end

--- a/spec/active_record_model_spec.rb
+++ b/spec/active_record_model_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+require "model"
+
+RSpec.describe Post do
+  include TappingDevice::Trackable
+
+  before do
+    Post.create!(title: "foo", content: "bar")
+  end
+
+  describe "triggering test" do
+    let(:locations) { [] }
+
+    before do
+      tap_init!(Post) do |payload|
+        locations << {path: payload[:filepath], line_number: payload[:line_number]}
+      end
+    end
+
+    it "triggers tapping when calling new" do
+      Post.new; line = __LINE__
+
+      expect(locations.first[:path]).to eq(__FILE__)
+      expect(locations.first[:line_number]).to eq(line.to_s)
+    end
+  end
+end

--- a/spec/model.rb
+++ b/spec/model.rb
@@ -8,8 +8,27 @@ ActiveRecord::Schema.define do
   create_table :posts, force: true  do |t|
     t.string :title
     t.string :content
+    t.references :user
+  end
+  create_table :users, force: true do |t|
+    t.string :name
+  end
+  create_table :comments, force: true do |t|
+    t.references :post
+    t.references :user
+    t.string :content
   end
 end
 
 class Post < ActiveRecord::Base
+  belongs_to :user
+end
+
+class User < ActiveRecord::Base
+  has_many :posts
+end
+
+class Comment < ActiveRecord::Base
+  belongs_to :post
+  belongs_to :user
 end

--- a/spec/model.rb
+++ b/spec/model.rb
@@ -1,0 +1,15 @@
+require 'active_record'
+
+# This connection will do for database-independent bug reports.
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.logger = nil
+
+ActiveRecord::Schema.define do
+  create_table :posts, force: true  do |t|
+    t.string :title
+    t.string :content
+  end
+end
+
+class Post < ActiveRecord::Base
+end

--- a/spec/model.rb
+++ b/spec/model.rb
@@ -22,10 +22,12 @@ end
 
 class Post < ActiveRecord::Base
   belongs_to :user
+  has_many :comments
 end
 
 class User < ActiveRecord::Base
   has_many :posts
+  has_many :comments
 end
 
 class Comment < ActiveRecord::Base

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "tapping_device"
 require "tapping_device/trackable"
+require "pry"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/tapping_device.gemspec
+++ b/tapping_device.gemspec
@@ -26,7 +26,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activerecord", "~> 6.0"
+
   spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/tapping_device.gemspec
+++ b/tapping_device.gemspec
@@ -26,10 +26,15 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~> 6.0"
+  if ENV["RAILS_VERSION"].to_i >= 6
+    spec.add_dependency "activerecord", "~> #{ENV["RAILS_VERSION"]}"
+    spec.add_development_dependency "sqlite3", "~> 1.4.1"
+  else
+    spec.add_dependency "activerecord", "~> 5.2"
+    spec.add_development_dependency "sqlite3", "~> 1.3.6"
+  end
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
This PR adds support to `ActiveRecord` models, including:
- `tap_init!(klass)` now returns the correct file path and line number for `Model.new` calls.
- Adds `tap_association_calls!` (`tap_assoc!`) method. This method only works on AR instances. It tracks calls for retrieving association records.

```ruby
class Post < ActiveRecord::Base
  has_many :comments
end

post = Post.last
tap_association_calls!(post) do |payload|
  puts("From #{payload[:filepath]}:#{payload[:line_number]}")
end

post.title #=> nothing
post.comments #=> From /Users/st0012/projects/tapping_device/spec/active_record_model_spec.rb:37
```
