### PR TITLE
Add Device class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,31 @@
 PATH
   remote: .
   specs:
-    tapping_device (0.1.0)
-      activerecord (~> 6.0)
+    tapping_device (0.1.1)
+      activerecord (~> 5.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.0)
-      activesupport (= 6.0.0)
-    activerecord (6.0.0)
-      activemodel (= 6.0.0)
-      activesupport (= 6.0.0)
-    activesupport (6.0.0)
+    activemodel (5.2.3)
+      activesupport (= 5.2.3)
+    activerecord (5.2.3)
+      activemodel (= 5.2.3)
+      activesupport (= 5.2.3)
+      arel (>= 9.0)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.1, >= 2.1.8)
+    arel (9.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
-    minitest (5.12.2)
+    minitest (5.13.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -42,11 +43,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    sqlite3 (1.4.1)
+    sqlite3 (1.3.13)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    zeitwerk (2.2.0)
 
 PLATFORMS
   ruby
@@ -56,7 +56,7 @@ DEPENDENCIES
   pry
   rake (~> 10.0)
   rspec (~> 3.0)
-  sqlite3 (~> 1.4.1)
+  sqlite3 (~> 1.3.6)
   tapping_device!
 
 BUNDLED WITH

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -1,5 +1,6 @@
 require "tapping_device/version"
 require "tapping_device/trackable"
+require "tapping_device/device"
 
 module TappingDevice
   class Error < StandardError; end

--- a/lib/tapping_device/device.rb
+++ b/lib/tapping_device/device.rb
@@ -21,6 +21,11 @@ module TappingDevice
       track(object, condition: :tap_on?, block: @block, **@options)
     end
 
+    def tap_assoc!(record)
+      raise "argument should be an instance of ActiveRecord::Base" unless record.is_a?(ActiveRecord::Base)
+      track(record, condition: :tap_associations?, block: @block, **@options)
+    end
+
     def set_block(&block)
       @block = block
     end

--- a/lib/tapping_device/device.rb
+++ b/lib/tapping_device/device.rb
@@ -4,9 +4,12 @@ module TappingDevice
   class Device
     include Trackable
 
+    attr_reader :options, :calls
+
     def initialize(options = {}, &block)
       @block = block
       @options = options
+      @calls = []
     end
 
     def tap_init!(klass)
@@ -16,6 +19,47 @@ module TappingDevice
 
     def stop!
       @tp.disable
+    end
+
+    private
+
+    def track(object, condition:, block:, with_trace_to: nil, exclude_by_paths: [], filter_by_paths: nil)
+      trace_point = TracePoint.trace(:return) do |tp|
+        filepath, line_number = caller(CALLER_START_POINT).first.split(":")[0..1]
+
+        # this needs to be placed upfront so we can exclude noise before doing more work
+        next if exclude_by_paths.any? { |pattern| pattern.match?(filepath) }
+
+        if filter_by_paths
+          next unless filter_by_paths.any? { |pattern| pattern.match?(filepath) }
+        end
+
+        arguments = tp.binding.local_variables.map { |n| [n, tp.binding.local_variable_get(n)] }
+
+        yield_parameters = {
+          receiver: tp.self,
+          method_name: tp.callee_id,
+          arguments: arguments,
+          return_value: (tp.return_value rescue nil),
+          filepath: filepath,
+          line_number: line_number,
+          defined_class: tp.defined_class,
+          trace: [],
+          tp: tp
+        }
+
+        yield_parameters[:trace] = caller[CALLER_START_POINT..(CALLER_START_POINT + with_trace_to)] if with_trace_to
+
+        if send(condition, object, yield_parameters)
+          if @block
+            @calls << block.call(yield_parameters)
+          else
+            @calls << yield_parameters
+          end
+        end
+      end
+
+      trace_point
     end
   end
 end

--- a/lib/tapping_device/device.rb
+++ b/lib/tapping_device/device.rb
@@ -1,0 +1,21 @@
+require "tapping_device/trackable"
+
+module TappingDevice
+  class Device
+    include Trackable
+
+    def initialize(options = {}, &block)
+      @block = block
+      @options = options
+    end
+
+    def tap_init!(klass)
+      raise "argument should be a class, got #{klass}" unless klass.is_a?(Class)
+      @tp = track(klass, condition: :tap_init?, block: @block, **@options)
+    end
+
+    def stop!
+      @tp.disable
+    end
+  end
+end

--- a/lib/tapping_device/device.rb
+++ b/lib/tapping_device/device.rb
@@ -14,17 +14,25 @@ module TappingDevice
 
     def tap_init!(klass)
       raise "argument should be a class, got #{klass}" unless klass.is_a?(Class)
-      @tp = track(klass, condition: :tap_init?, block: @block, **@options)
+      track(klass, condition: :tap_init?, block: @block, **@options)
+    end
+
+    def tap_on!(object)
+      track(object, condition: :tap_on?, block: @block, **@options)
+    end
+
+    def set_block(&block)
+      @block = block
     end
 
     def stop!
-      @tp.disable
+      @trace_point.disable if @trace_point
     end
 
     private
 
     def track(object, condition:, block:, with_trace_to: nil, exclude_by_paths: [], filter_by_paths: nil)
-      trace_point = TracePoint.trace(:return) do |tp|
+      @trace_point = TracePoint.trace(:return) do |tp|
         filepath, line_number = caller(CALLER_START_POINT).first.split(":")[0..1]
 
         # this needs to be placed upfront so we can exclude noise before doing more work
@@ -58,8 +66,6 @@ module TappingDevice
           end
         end
       end
-
-      trace_point
     end
   end
 end

--- a/lib/tapping_device/device.rb
+++ b/lib/tapping_device/device.rb
@@ -71,6 +71,8 @@ module TappingDevice
           end
         end
       end
+
+      self
     end
   end
 end

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -1,10 +1,5 @@
-require "active_record"
-
 module TappingDevice
   module Trackable
-    TAPPING_DEVICE = :@tapping_device
-    CALLER_START_POINT = 2
-
     def tap_init!(klass, options = {}, &block)
       Device.new(options, &block).tap_init!(klass)
     end
@@ -15,40 +10,6 @@ module TappingDevice
 
     def tap_on!(object, options = {}, &block)
       Device.new(options, &block).tap_on!(object)
-    end
-
-    private
-
-    def tap_init?(klass, parameters)
-      receiver = parameters[:receiver]
-      method_name = parameters[:method_name]
-
-      if klass.ancestors.include?(ActiveRecord::Base)
-        method_name == :new && receiver.ancestors.include?(klass)
-      else
-        method_name == :initialize && receiver.is_a?(klass)
-      end
-    end
-
-    def tap_on?(object, parameters)
-      parameters[:receiver].object_id == object.object_id
-    end
-
-    def tap_associations?(object, parameters)
-      return false unless tap_on?(object, parameters)
-
-      model_class = object.class
-      associations = model_class.reflections
-      associations.keys.include?(parameters[:method_name].to_s)
-    end
-
-    def get_tapping_device(object)
-      object.instance_variable_get(TAPPING_DEVICE)
-    end
-
-    def add_tapping_device(object, trace_point)
-      object.instance_variable_set(TAPPING_DEVICE, []) unless get_tapping_device(object)
-      object.instance_variable_get(TAPPING_DEVICE) << trace_point
     end
   end
 end

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -61,6 +61,7 @@ module TappingDevice
       end
 
       add_tapping_device(object, trace_point)
+      trace_point
     end
 
     def tap_init?(klass, parameters)

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -6,58 +6,18 @@ module TappingDevice
     CALLER_START_POINT = 2
 
     def tap_init!(klass, options = {}, &block)
-      raise "argument should be a class, got #{klass}" unless klass.is_a?(Class)
-      track(klass, condition: :tap_init?, block: block, **options)
+      Device.new(options, &block).tap_init!(klass)
     end
 
     def tap_assoc!(record, options = {}, &block)
-      raise "argument should be an instance of ActiveRecord::Base" unless record.is_a?(ActiveRecord::Base)
-      track(record, condition: :tap_associations?, block: block, **options)
+      Device.new(options, &block).tap_assoc!(record)
     end
 
     def tap_on!(object, options = {}, &block)
-      track(object, condition: :tap_on?, block: block, **options)
-    end
-
-    def untap!(object)
-      get_tapping_device(object)&.each { |tp| tp.disable }
+      Device.new(options, &block).tap_on!(object)
     end
 
     private
-
-    def track(object, condition:, block:, with_trace_to: nil, exclude_by_paths: [], filter_by_paths: nil)
-      trace_point = TracePoint.trace(:return) do |tp|
-        filepath, line_number = caller(CALLER_START_POINT).first.split(":")[0..1]
-
-        # this needs to be placed upfront so we can exclude noise before doing more work
-        next if exclude_by_paths.any? { |pattern| pattern.match?(filepath) }
-
-        if filter_by_paths
-          next unless filter_by_paths.any? { |pattern| pattern.match?(filepath) }
-        end
-
-        arguments = tp.binding.local_variables.map { |n| [n, tp.binding.local_variable_get(n)] }
-
-        yield_parameters = {
-          receiver: tp.self,
-          method_name: tp.callee_id,
-          arguments: arguments,
-          return_value: (tp.return_value rescue nil),
-          filepath: filepath,
-          line_number: line_number,
-          defined_class: tp.defined_class,
-          trace: [],
-          tp: tp
-        }
-
-        yield_parameters[:trace] = caller[CALLER_START_POINT..(CALLER_START_POINT + with_trace_to)] if with_trace_to
-
-        block.call(yield_parameters) if send(condition, object, yield_parameters)
-      end
-
-      add_tapping_device(object, trace_point)
-      trace_point
-    end
 
     def tap_init?(klass, parameters)
       receiver = parameters[:receiver]

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -5,28 +5,23 @@ module TappingDevice
     TAPPING_DEVICE = :@tapping_device
     CALLER_START_POINT = 2
 
-    def tap_initialization_of!(klass, options = {}, &block)
+    def tap_init!(klass, options = {}, &block)
       raise "argument should be a class, got #{klass}" unless klass.is_a?(Class)
       track(klass, condition: :tap_init?, block: block, **options)
     end
 
-    def tap_association_calls!(record, options = {}, &block)
+    def tap_assoc!(record, options = {}, &block)
       raise "argument should be an instance of ActiveRecord::Base" unless record.is_a?(ActiveRecord::Base)
       track(record, condition: :tap_associations?, block: block, **options)
     end
 
-    def tap_calls_on!(object, options = {}, &block)
+    def tap_on!(object, options = {}, &block)
       track(object, condition: :tap_on?, block: block, **options)
     end
 
-    def stop_tapping!(object)
+    def untap!(object)
       get_tapping_device(object)&.each { |tp| tp.disable }
     end
-
-    alias :tap_init! :tap_initialization_of!
-    alias :tap_assoc! :tap_association_calls!
-    alias :tap_on! :tap_calls_on!
-    alias :untap! :stop_tapping!
 
     private
 

--- a/spec/active_record_model_spec.rb
+++ b/spec/active_record_model_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe "ActiveRecord model spec" do
     end
   end
 
-  describe "#tap_association_calls!" do
+  describe "#tap_assoc!" do
     let(:user) { User.create!(name: "Stan") }
     let(:post) { Post.create!(title: "foo", content: "bar", user: user) }
     let!(:comment) { Comment.create!(post: post, user: user, content: "Nice post!") }
 
     it "tracks every association calls" do
-      tap_association_calls!(post) do |payload|
+      tap_assoc!(post) do |payload|
         locations << {path: payload[:filepath], line_number: payload[:line_number]}
       end
 

--- a/spec/active_record_model_spec.rb
+++ b/spec/active_record_model_spec.rb
@@ -46,3 +46,31 @@ RSpec.describe "ActiveRecord model spec" do
     end
   end
 end
+
+
+RSpec.describe TappingDevice::Device do
+  describe "#tap_assoc!" do
+    let(:user) { User.create!(name: "Stan") }
+    let(:post) { Post.create!(title: "foo", content: "bar", user: user) }
+    let!(:comment) { Comment.create!(post: post, user: user, content: "Nice post!") }
+
+    it "tracks every association calls" do
+      locations = []
+
+      device = described_class.new do |payload|
+        locations << {path: payload[:filepath], line_number: payload[:line_number]}
+      end
+      device.tap_assoc!(post)
+
+      post.user; line_1 = __LINE__
+      post.title
+      post.comments; line_2 = __LINE__
+
+      expect(locations.count).to eq(2)
+      expect(locations[0][:path]).to eq(__FILE__)
+      expect(locations[0][:line_number]).to eq(line_1.to_s)
+      expect(locations[1][:path]).to eq(__FILE__)
+      expect(locations[1][:line_number]).to eq(line_2.to_s)
+    end
+  end
+end

--- a/spec/model.rb
+++ b/spec/model.rb
@@ -34,3 +34,38 @@ class Comment < ActiveRecord::Base
   belongs_to :post
   belongs_to :user
 end
+
+class Student
+  def initialize(name, age)
+    @name = name
+    @age = age
+  end
+
+  def self.foo; end
+
+  def name
+    @name
+  end
+
+  def age
+    @age
+  end
+
+  def age=(age)
+    @age = age
+  end
+end
+
+class HighSchoolStudent < Student;end
+
+class School
+  def initialize(name)
+    @name = name
+  end
+
+  def name
+    @name
+  end
+end
+
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,8 @@
-require "bundler/setup"
 require "tapping_device"
 require "tapping_device/trackable"
+require "bundler/setup"
 require "pry"
+require "model"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/tapping_device_spec.rb
+++ b/spec/tapping_device_spec.rb
@@ -181,4 +181,23 @@ RSpec.describe TappingDevice::Device do
       end
     end
   end
+
+  describe "#stop!" do
+    it "stopps tapping" do
+      count = 0
+      device = described_class.new do |options|
+        count += 1
+      end
+      device.tap_init!(Student)
+
+
+      Student.new("Stan", 18)
+
+      device.stop!
+
+      Student.new("Jane", 23)
+
+      expect(count).to eq(1)
+    end
+  end
 end

--- a/spec/tapping_device_spec.rb
+++ b/spec/tapping_device_spec.rb
@@ -1,64 +1,41 @@
 require "spec_helper"
 
 RSpec.describe TappingDevice::Device do
-  describe "#tap_initialization_of!" do
+  describe "#tap_init!" do
+    let(:device) { TappingDevice::Device.new }
+
+    after do
+      device.stop!
+    end
+
     it "tracks Student's initialization" do
-      count = 0
-
-      device = TappingDevice::Device.new do
-        count += 1
-      end
-
       device.tap_init!(Student)
 
       Student.new("Stan", 18)
       Student.new("Jane", 23)
 
-      expect(count).to eq(2)
-
-      device.stop!
+      expect(device.calls.count).to eq(2)
     end
     it "can track subclass's initialization as well" do
-      count = 0
-
-      device = TappingDevice::Device.new do
-        count += 1
-      end
-
       device.tap_init!(HighSchoolStudent)
 
       HighSchoolStudent.new("Stan", 18)
 
-      expect(count).to eq(1)
-      device.stop!
+      expect(device.calls.count).to eq(1)
     end
     it "doesn't track School's initialization" do
-      count = 0
-
-      device = TappingDevice::Device.new do
-        count += 1
-      end
-
       device.tap_init!(Student)
 
       School.new("A school")
 
-      expect(count).to eq(0)
-      device.stop!
+      expect(device.calls.count).to eq(0)
     end
     it "doesn't track non-initialization method calls" do
-      count = 0
-
-      device = TappingDevice::Device.new do
-        count += 1
-      end
-
       device.tap_init!(Student)
 
       Student.foo
 
-      expect(count).to eq(0)
-      device.stop!
+      expect(device.calls.count).to eq(0)
     end
   end
 end

--- a/spec/tapping_device_spec.rb
+++ b/spec/tapping_device_spec.rb
@@ -1,5 +1,64 @@
-RSpec.describe TappingDevice do
-  it "has a version number" do
-    expect(TappingDevice::VERSION).not_to be nil
+require "spec_helper"
+
+RSpec.describe TappingDevice::Device do
+  describe "#tap_initialization_of!" do
+    it "tracks Student's initialization" do
+      count = 0
+
+      device = TappingDevice::Device.new do
+        count += 1
+      end
+
+      device.tap_init!(Student)
+
+      Student.new("Stan", 18)
+      Student.new("Jane", 23)
+
+      expect(count).to eq(2)
+
+      device.stop!
+    end
+    it "can track subclass's initialization as well" do
+      count = 0
+
+      device = TappingDevice::Device.new do
+        count += 1
+      end
+
+      device.tap_init!(HighSchoolStudent)
+
+      HighSchoolStudent.new("Stan", 18)
+
+      expect(count).to eq(1)
+      device.stop!
+    end
+    it "doesn't track School's initialization" do
+      count = 0
+
+      device = TappingDevice::Device.new do
+        count += 1
+      end
+
+      device.tap_init!(Student)
+
+      School.new("A school")
+
+      expect(count).to eq(0)
+      device.stop!
+    end
+    it "doesn't track non-initialization method calls" do
+      count = 0
+
+      device = TappingDevice::Device.new do
+        count += 1
+      end
+
+      device.tap_init!(Student)
+
+      Student.foo
+
+      expect(count).to eq(0)
+      device.stop!
+    end
   end
 end

--- a/spec/tapping_device_spec.rb
+++ b/spec/tapping_device_spec.rb
@@ -38,4 +38,147 @@ RSpec.describe TappingDevice::Device do
       expect(device.calls.count).to eq(0)
     end
   end
+
+  describe "#tap_on!" do
+    let(:device) do
+      TappingDevice::Device.new do |payload|
+        [payload[:receiver].object_id, payload[:method_name], payload[:return_value]]
+      end
+    end
+
+    after do
+      device.stop!
+    end
+
+    it "tracks method calls on the tapped object" do
+      stan = Student.new("Stan", 18)
+      jane = Student.new("Jane", 23)
+
+      device.tap_on!(stan)
+
+      stan.name
+      stan.age
+      jane.name
+      jane.age
+
+      expect(device.calls).to match_array(
+        [
+          [stan.object_id, :name, "Stan"],
+          [stan.object_id, :age, 18]
+        ]
+      )
+    end
+    it "supports multiple tappings" do
+      stan = Student.new("Stan", 18)
+
+      count_1 = 0
+      count_2 = 0
+
+      device_1 = described_class.new { count_1 += 1 }
+      device_2 = described_class.new { count_2 -= 1 }
+
+      device_1.tap_on!(stan)
+      device_2.tap_on!(stan)
+
+      stan.name
+
+      expect(count_1).to eq(1)
+      expect(count_2).to eq(-1)
+
+      device_1.stop!
+      device_2.stop!
+    end
+    it "tracks alias" do
+      c = Class.new(Student)
+      c.class_eval do
+        alias :alias_name :name
+      end
+      stan = c.new("Stan", 18)
+
+      names = []
+
+      device.set_block do |payload|
+        names << payload[:method_name]
+      end
+
+      device.tap_on!(stan)
+
+      stan.alias_name
+
+      expect(names).to match_array([:alias_name])
+    end
+
+    describe "yield parameters" do
+      it "detects correct arguments" do
+        stan = Student.new("Stan", 18)
+
+        arguments = []
+
+        device.set_block do |payload|
+          arguments = payload[:arguments]
+        end
+
+        device.tap_on!(stan)
+
+        stan.age = (25)
+
+        expect(arguments).to eq([[:age, 25]])
+      end
+      it "returns correct filepath and line number" do
+        stan = Student.new("Stan", 18)
+
+        filepath = ""
+        line_number = 0
+
+        device.set_block do |payload|
+          filepath = payload[:filepath]
+          line_number = payload[:line_number]
+        end
+
+        device.tap_on!(stan)
+
+        line_mark = __LINE__
+        stan.age
+
+        expect(filepath).to eq(__FILE__)
+        expect(line_number).to eq((line_mark+1).to_s)
+      end
+    end
+
+    describe "options - exclude_by_paths: [/path/]" do
+      it "skips calls that matches the pattern" do
+        stan = Student.new("Stan", 18)
+        count = 0
+
+        device = described_class.new(exclude_by_paths: [/spec/]) { count += 1 }
+        device.tap_on!(stan)
+
+        stan.name
+
+        expect(count).to eq(0)
+        device.stop!
+      end
+    end
+    describe "options - filter_by_paths: [/path/]" do
+      it "skips calls that matches the pattern" do
+        stan = Student.new("Stan", 18)
+        count = 0
+
+        device_1 = described_class.new(filter_by_paths: [/lib/]) { count += 1 }
+        device_1.tap_on!(stan)
+
+        stan.name
+        expect(count).to eq(0)
+
+        device_2 = described_class.new(filter_by_paths: [/spec/]) { count += 1 }
+        device_2.tap_on!(stan)
+
+        stan.name
+        expect(count).to eq(1)
+
+        device_1.stop!
+        device_2.stop!
+      end
+    end
+  end
 end

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -4,14 +4,6 @@ RSpec.describe TappingDevice::Trackable do
   include described_class
 
   describe "#tap_init!" do
-    before do
-      untap!(Student)
-    end
-
-    after do
-      untap!(Student)
-    end
-
     it "tracks Student's initialization" do
       count = 0
       tap_init!(Student) do |options|
@@ -25,7 +17,7 @@ RSpec.describe TappingDevice::Trackable do
     end
     it "can track subclass's initialization as well" do
       count = 0
-      tap_init!(HighSchoolStudent) do |options|
+      device = tap_init!(HighSchoolStudent) do |options|
         count += 1
       end
 
@@ -33,7 +25,7 @@ RSpec.describe TappingDevice::Trackable do
 
       expect(count).to eq(1)
 
-      untap!(HighSchoolStudent)
+      device.stop!
     end
     it "doesn't track School's initialization" do
       count = 0
@@ -159,53 +151,16 @@ RSpec.describe TappingDevice::Trackable do
         stan = Student.new("Stan", 18)
         count = 0
 
-        tap_on!(stan, filter_by_paths: [/lib/]) { count += 1 }
+        device = tap_on!(stan, filter_by_paths: [/lib/]) { count += 1 }
         stan.name
         expect(count).to eq(0)
-        untap!(stan)
+
+        device.stop!
 
         tap_on!(stan, filter_by_paths: [/spec/]) { count += 1 }
         stan.name
         expect(count).to eq(1)
       end
-    end
-  end
-
-  describe "#untap!" do
-    it "stopps tapping" do
-      count = 0
-      tap_init!(Student) do |options|
-        count += 1
-      end
-
-      Student.new("Stan", 18)
-
-      untap!(Student)
-
-      Student.new("Jane", 23)
-
-      expect(count).to eq(1)
-    end
-    it "stops multiple tappings" do
-      stan = Student.new("Stan", 18)
-
-      count_1 = 0
-      count_2 = 0
-
-      tap_on!(stan) { count_1 += 1 }
-      tap_on!(stan) { count_2 -= 1 }
-
-      stan.name
-
-      expect(count_1).to eq(1)
-      expect(count_2).to eq(-1)
-
-      untap!(stan)
-
-      stan.name
-
-      expect(count_1).to eq(1)
-      expect(count_2).to eq(-1)
     end
   end
 end

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -1,38 +1,5 @@
 require "spec_helper"
 
-class Student
-  def initialize(name, age)
-    @name = name
-    @age = age
-  end
-
-  def self.foo; end
-
-  def name
-    @name
-  end
-
-  def age
-    @age
-  end
-
-  def age=(age)
-    @age = age
-  end
-end
-
-class HighSchoolStudent < Student;end
-
-class School
-  def initialize(name)
-    @name = name
-  end
-
-  def name
-    @name
-  end
-end
-
 RSpec.describe TappingDevice::Trackable do
   include described_class
 

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -3,18 +3,18 @@ require "spec_helper"
 RSpec.describe TappingDevice::Trackable do
   include described_class
 
-  describe "#tap_initialization_of!" do
+  describe "#tap_init!" do
     before do
-      stop_tapping!(Student)
+      untap!(Student)
     end
 
     after do
-      stop_tapping!(Student)
+      untap!(Student)
     end
 
     it "tracks Student's initialization" do
       count = 0
-      tap_initialization_of!(Student) do |options|
+      tap_init!(Student) do |options|
         count += 1
       end
 
@@ -25,7 +25,7 @@ RSpec.describe TappingDevice::Trackable do
     end
     it "can track subclass's initialization as well" do
       count = 0
-      tap_initialization_of!(HighSchoolStudent) do |options|
+      tap_init!(HighSchoolStudent) do |options|
         count += 1
       end
 
@@ -33,11 +33,11 @@ RSpec.describe TappingDevice::Trackable do
 
       expect(count).to eq(1)
 
-      stop_tapping!(HighSchoolStudent)
+      untap!(HighSchoolStudent)
     end
     it "doesn't track School's initialization" do
       count = 0
-      tap_initialization_of!(Student) do |options|
+      tap_init!(Student) do |options|
         count += 1
       end
 
@@ -47,7 +47,7 @@ RSpec.describe TappingDevice::Trackable do
     end
     it "doesn't track non-initialization method calls" do
       count = 0
-      tap_initialization_of!(Student) do |options|
+      tap_init!(Student) do |options|
         count += 1
       end
 
@@ -57,13 +57,13 @@ RSpec.describe TappingDevice::Trackable do
     end
   end
 
-  describe "#tap_calls_on!" do
+  describe "#tap_on!" do
     it "tracks method calls on the tapped object" do
       stan = Student.new("Stan", 18)
       jane = Student.new("Jane", 23)
 
       calls = []
-      tap_calls_on!(stan) do |payload|
+      tap_on!(stan) do |payload|
         calls << [payload[:receiver].object_id, payload[:method_name], payload[:return_value]]
       end
 
@@ -85,8 +85,8 @@ RSpec.describe TappingDevice::Trackable do
       count_1 = 0
       count_2 = 0
 
-      tap_calls_on!(stan) { count_1 += 1 }
-      tap_calls_on!(stan) { count_2 -= 1 }
+      tap_on!(stan) { count_1 += 1 }
+      tap_on!(stan) { count_2 -= 1 }
 
       stan.name
 
@@ -101,7 +101,7 @@ RSpec.describe TappingDevice::Trackable do
       stan = c.new("Stan", 18)
 
       names = []
-      tap_calls_on!(stan) do |payload|
+      tap_on!(stan) do |payload|
         names << payload[:method_name]
       end
 
@@ -116,7 +116,7 @@ RSpec.describe TappingDevice::Trackable do
 
         arguments = []
 
-        tap_calls_on!(stan) do |payload|
+        tap_on!(stan) do |payload|
           arguments = payload[:arguments]
         end
 
@@ -130,7 +130,7 @@ RSpec.describe TappingDevice::Trackable do
         filepath = ""
         line_number = 0
 
-        tap_calls_on!(stan) do |payload|
+        tap_on!(stan) do |payload|
           filepath = payload[:filepath]
           line_number = payload[:line_number]
         end
@@ -147,7 +147,7 @@ RSpec.describe TappingDevice::Trackable do
       it "skips calls that matches the pattern" do
         stan = Student.new("Stan", 18)
         count = 0
-        tap_calls_on!(stan, exclude_by_paths: [/spec/]) { count += 1 }
+        tap_on!(stan, exclude_by_paths: [/spec/]) { count += 1 }
 
         stan.name
 
@@ -159,28 +159,28 @@ RSpec.describe TappingDevice::Trackable do
         stan = Student.new("Stan", 18)
         count = 0
 
-        tap_calls_on!(stan, filter_by_paths: [/lib/]) { count += 1 }
+        tap_on!(stan, filter_by_paths: [/lib/]) { count += 1 }
         stan.name
         expect(count).to eq(0)
         untap!(stan)
 
-        tap_calls_on!(stan, filter_by_paths: [/spec/]) { count += 1 }
+        tap_on!(stan, filter_by_paths: [/spec/]) { count += 1 }
         stan.name
         expect(count).to eq(1)
       end
     end
   end
 
-  describe "#stop_tapping!" do
+  describe "#untap!" do
     it "stopps tapping" do
       count = 0
-      tap_initialization_of!(Student) do |options|
+      tap_init!(Student) do |options|
         count += 1
       end
 
       Student.new("Stan", 18)
 
-      stop_tapping!(Student)
+      untap!(Student)
 
       Student.new("Jane", 23)
 
@@ -192,15 +192,15 @@ RSpec.describe TappingDevice::Trackable do
       count_1 = 0
       count_2 = 0
 
-      tap_calls_on!(stan) { count_1 += 1 }
-      tap_calls_on!(stan) { count_2 -= 1 }
+      tap_on!(stan) { count_1 += 1 }
+      tap_on!(stan) { count_2 -= 1 }
 
       stan.name
 
       expect(count_1).to eq(1)
       expect(count_2).to eq(-1)
 
-      stop_tapping!(stan)
+      untap!(stan)
 
       stan.name
 


### PR DESCRIPTION
`TappingDevice::Device` is a wrapper object that contains info like block, options, calls and the trace point object. With this object holding this info (instead of throwing them away after calling tap methods) allow us to add more features, e.g. Add conditions to stop tracing.

The only breaking change is we now drop `untap!` method due to implementation incompatibility. Other methods should behave the same.