### PR TITLE
Support `TappingDevice::Device#stop_when`

### DIFF
--- a/lib/tapping_device/exceptions.rb
+++ b/lib/tapping_device/exceptions.rb
@@ -1,0 +1,4 @@
+module TappingDevice
+  class Exception < StandardError
+  end
+end

--- a/spec/performance_spec.rb
+++ b/spec/performance_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+require 'benchmark'
+
+RSpec.describe TappingDevice::Device do
+  let(:devices) do
+    devices = []
+    100.times { devices << TappingDevice::Device.new }
+    devices
+  end
+
+  after do
+    devices.each(&:stop!)
+  end
+
+  context "without stop_when" do
+    it "takes long time when tapping multiple devices" do
+      time = Benchmark.realtime do
+        devices.each do |device|
+          s = Student.new("foo", 10)
+          device.tap_on!(s)
+          10.times { s.name }
+
+          expect(device.calls.count).to eq(10)
+        end
+      end
+      devices.each { |d| d.stop! }
+      expect(time).to be_between(4, 10)
+    end
+  end
+
+  context "with stop_when" do
+    it "takes very short time when tapping multiple devices" do
+      time = Benchmark.realtime do
+        devices.each do |device|
+          device.stop_when do
+            device.calls.count == 10
+          end
+
+          s = Student.new("foo", 10)
+          device.tap_on!(s)
+          10.times { s.name }
+
+          expect(device.calls.count).to eq(10)
+        end
+      end
+
+      devices.each { |d| d.stop! }
+      expect(time).to be_between(0, 1)
+    end
+  end
+end

--- a/spec/tapping_device_spec.rb
+++ b/spec/tapping_device_spec.rb
@@ -200,4 +200,49 @@ RSpec.describe TappingDevice::Device do
       expect(count).to eq(1)
     end
   end
+
+  describe "#tap_init" do
+    let(:device) { TappingDevice::Device.new }
+    let(:stan) { Student.new("stan", 25) }
+
+    it "raises error if device has no stop_when set" do
+      expect { device.tap_init(Student) }.to raise_error(TappingDevice::Exception)
+    end
+  end
+
+  describe "#tap_on" do
+    let(:device) { TappingDevice::Device.new }
+    let(:stan) { Student.new("stan", 25) }
+
+    it "raises error if device has no stop_when set" do
+      expect { device.tap_on(stan) }.to raise_error(TappingDevice::Exception)
+    end
+  end
+
+  describe "#tap_assoc" do
+    let(:device) { TappingDevice::Device.new }
+    let(:post) { Post.new }
+
+    it "raises error if device has no stop_when set" do
+      expect { device.tap_assoc(post) }.to raise_error(TappingDevice::Exception)
+    end
+  end
+
+  describe "#stop_when" do
+    it "stops tapping once fulfill stop_when condition" do
+      device = TappingDevice::Device.new
+      device.stop_when do |payload|
+        device.calls.count == 10
+      end
+
+      s = Student.new("foo#", 10)
+      device.tap_on!(s)
+
+      100.times do
+        s.name
+      end
+
+      expect(device.calls.count).to eq(10)
+    end
+  end
 end


### PR DESCRIPTION
The biggest issue `tapping_device` has is about performance. This is because `TracePoint` literally taps every method call on every object if nothing disables it. So using `tapping_device` on a large application with multiple tappings can be extremely slow or even hang your application.

This PR tries to solve this issue by:

1. Adding `TappingDevice::Device#stop_when` to let users add stop condition. Once the block evaluation returns anything truthy, the tapping would be stopped.

2. Adding `tap_init`, `tap_on` and `tap_assoc` methods, which will first check if `stop_when` condition is provided and raise exception if not.
