### PR TITLE
Minor adjustment

### DIFF
--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -122,8 +122,6 @@ class TappingDevice
     self
   end
 
-  private
-
   def tap_init?(klass, parameters)
     receiver = parameters[:receiver]
     method_name = parameters[:method_name]

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -82,31 +82,30 @@ class TappingDevice
       }
 
       if send(condition, object, validation_params)
+        filepath, line_number = caller(CALLER_START_POINT).first.split(":")[0..1]
 
-      filepath, line_number = caller(CALLER_START_POINT).first.split(":")[0..1]
+        # this needs to be placed upfront so we can exclude noise before doing more work
+        next if exclude_by_paths.any? { |pattern| pattern.match?(filepath) }
 
-      # this needs to be placed upfront so we can exclude noise before doing more work
-      next if exclude_by_paths.any? { |pattern| pattern.match?(filepath) }
+        if filter_by_paths
+          next unless filter_by_paths.any? { |pattern| pattern.match?(filepath) }
+        end
 
-      if filter_by_paths
-        next unless filter_by_paths.any? { |pattern| pattern.match?(filepath) }
-      end
+        arguments = tp.binding.local_variables.map { |n| [n, tp.binding.local_variable_get(n)] }
 
-      arguments = tp.binding.local_variables.map { |n| [n, tp.binding.local_variable_get(n)] }
+        yield_parameters = {
+          receiver: tp.self,
+          method_name: tp.callee_id,
+          arguments: arguments,
+          return_value: (tp.return_value rescue nil),
+          filepath: filepath,
+          line_number: line_number,
+          defined_class: tp.defined_class,
+          trace: [],
+          tp: tp
+        }
 
-      yield_parameters = {
-        receiver: tp.self,
-        method_name: tp.callee_id,
-        arguments: arguments,
-        return_value: (tp.return_value rescue nil),
-        filepath: filepath,
-        line_number: line_number,
-        defined_class: tp.defined_class,
-        trace: [],
-        tp: tp
-      }
-
-      yield_parameters[:trace] = caller[CALLER_START_POINT..(CALLER_START_POINT + with_trace_to)] if with_trace_to
+        yield_parameters[:trace] = caller[CALLER_START_POINT..(CALLER_START_POINT + with_trace_to)] if with_trace_to
         if @block
           @calls << block.call(yield_parameters)
         else


### PR DESCRIPTION
- [x] remove duplicate `private`
- [x] adjust indentation to increase readability

# Details

Compare to [v0.3.0](https://github.com/st0012/tapping_device/tree/v0.3.0), 
- call `private` twice in [line 75](https://github.com/st0012/tapping_device/blob/v0.3.0/lib/tapping_device.rb#L75) and [line 125](https://github.com/st0012/tapping_device/blob/v0.3.0/lib/tapping_device.rb#L125), so removed second `private`. 
- [line 84](https://github.com/st0012/tapping_device/blob/v0.3.0/lib/tapping_device.rb#L84)  and [range #L86-L109](https://github.com/st0012/tapping_device/blob/v0.3.0/lib/tapping_device.rb#L86-L109) easy to make people confusion, inside `if ... end`  using indention better, so I adjust it.



