### PR TITLE
Add TappingDevice::Payload class

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,7 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
     - name: Install sqlite
       run: |
+        sudo apt-get update
         sudo apt-get install libsqlite3-dev
 
     - name: Build and test with Rails ${{ matrix.rails_version }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tapping_device (0.3.0)
+    tapping_device (0.4.0)
       activerecord (>= 5.2)
 
 GEM

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -1,5 +1,6 @@
 require "active_record"
 require "tapping_device/version"
+require "tapping_device/payload"
 require "tapping_device/trackable"
 require "tapping_device/exceptions"
 require "tapping_device/sql_tapping_methods"
@@ -152,7 +153,7 @@ class TappingDevice
   def build_yield_parameters(tp:, filepath:, line_number:)
     arguments = tp.binding.local_variables.map { |n| [n, tp.binding.local_variable_get(n)] }
 
-    {
+    Payload.init({
       receiver: tp.self,
       method_name: tp.callee_id,
       arguments: arguments,
@@ -162,7 +163,7 @@ class TappingDevice
       defined_class: tp.defined_class,
       trace: caller[CALLER_START_POINT..(CALLER_START_POINT + options[:with_trace_to])],
       tp: tp
-    }
+    })
   end
 
   def tap_init?(klass, parameters)

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -19,5 +19,9 @@ class TappingDevice
     def method_name_and_location
       "Method: :#{method_name}, line: #{filepath}:#{line_number}"
     end
+
+    def method_name_and_arguments
+      "Method: :#{method_name}, argments: #{arguments.to_s}"
+    end
   end
 end

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -16,7 +16,7 @@ class TappingDevice
       h
     end
 
-    def what_and_where
+    def method_name_and_location
       "Method: :#{method_name}, line: #{filepath}:#{line_number}"
     end
   end

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -15,5 +15,9 @@ class TappingDevice
       end
       h
     end
+
+    def what_and_where
+      "Method: :#{method_name}, line: #{filepath}:#{line_number}"
+    end
   end
 end

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -1,0 +1,19 @@
+class TappingDevice
+  class Payload < Hash
+    ATTRS = [:receiver, :method_name, :arguments, :return_value, :filepath, :line_number, :defined_class, :trace, :tp]
+
+    ATTRS.each do |attr|
+      define_method attr do
+        self[attr]
+      end
+    end
+
+    def self.init(hash)
+      h = new
+      hash.each do |k, v|
+        h[k] = v
+      end
+      h
+    end
+  end
+end

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+RSpec.describe TappingDevice::Payload do
+  subject do
+    device = TappingDevice.new
+    device.tap_init!(Student)
+    Student.new("Stan", 25)
+    device.calls.first
+  end
+
+  it "supports payload attributes as methods" do
+    expect(subject.receiver).to be_is_a(Student)
+    expect(subject.arguments).to eq([[:name, "Stan"], [:age, 25]])
+    expect(subject.keys).to eq(
+      [
+        :receiver,
+        :method_name,
+        :arguments,
+        :return_value,
+        :filepath,
+        :line_number,
+        :defined_class,
+        :trace,
+        :tp
+      ]
+    )
+  end
+end

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -31,4 +31,10 @@ RSpec.describe TappingDevice::Payload do
       expect(subject.method_name_and_location).to match(/Method: :initialize, line: .+\/tapping_device\/spec\/payload_spec.rb:\d/)
     end
   end
+  describe "#method_name_and_arguments" do
+    it "returns method's name and its arguments" do
+      expect(subject.method_name_and_arguments).to match("Method: :initialize, argments: [[:name, \"Stan\"], [:age, 25]]")
+    end
+  end
+
 end

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe TappingDevice::Payload do
 
   describe "#method_name_and_location" do
     it "returns method's name and where it's called" do
+      puts(subject.method_name_and_location)
       expect(subject.method_name_and_location).to match(/Method: :initialize, line: .+\/tapping_device\/spec\/payload_spec.rb:\d/)
     end
   end

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe TappingDevice::Payload do
     )
   end
 
-  describe "#what_and_where" do
+  describe "#method_name_and_location" do
     it "returns method's name and where it's called" do
-      expect(subject.what_and_where).to match(/Method: :initialize, line: .+\/tapping_device\/spec\/payload_spec.rb:\d/)
+      expect(subject.method_name_and_location).to match(/Method: :initialize, line: .+\/tapping_device\/spec\/payload_spec.rb:\d/)
     end
   end
 end

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -25,4 +25,10 @@ RSpec.describe TappingDevice::Payload do
       ]
     )
   end
+
+  describe "#what_and_where" do
+    it "returns method's name and where it's called" do
+      expect(subject.what_and_where).to match(/Method: :initialize, line: .+\/tapping_device\/spec\/payload_spec.rb:\d/)
+    end
+  end
 end


### PR DESCRIPTION
Wrapping the payload in a custom class allows us to add some helper methods to it, which can make it easier for users to use.