### PR TITLE
Implement tap_passed!

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,8 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
     - name: Install sqlite
       run: |
+        # See https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/td-p/41122/page/2
+        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install libsqlite3-dev
 

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -73,16 +73,6 @@ class TappingDevice
     options[:descendants]
   end
 
-  def record_call!(payload)
-    return if @disabled
-
-    if @block
-      root_device.calls << @block.call(payload)
-    else
-      root_device.calls << payload
-    end
-  end
-
   private
 
   def track(object, condition:)
@@ -148,7 +138,7 @@ class TappingDevice
   end
 
   def tap_on?(object, tp)
-    tp.self.__id__ == object.__id__
+    is_from_target?(object, tp)
   end
 
   def tap_associations?(object, tp)
@@ -187,5 +177,15 @@ class TappingDevice
 
   def is_from_target?(object, tp)
     object.__id__ == tp.self.__id__
+  end
+
+  def record_call!(payload)
+    return if @disabled
+
+    if @block
+      root_device.calls << @block.call(payload)
+    else
+      root_device.calls << payload
+    end
   end
 end

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -119,6 +119,7 @@ class TappingDevice
       target: @target,
       receiver: tp.self,
       method_name: tp.callee_id,
+      method_object: get_method_object_from(tp.self, tp.callee_id),
       arguments: arguments,
       return_value: (tp.return_value rescue nil),
       filepath: filepath,

--- a/lib/tapping_device/manageable.rb
+++ b/lib/tapping_device/manageable.rb
@@ -1,0 +1,37 @@
+class TappingDevice
+  module Manageable
+
+    def suspend_new
+      @suspend_new
+    end
+
+    # list all registered devices
+    def devices
+      @devices
+    end
+
+    # disable given device and remove it from registered list
+    def delete_device(device)
+      device.trace_point&.disable
+      @devices -= [device]
+    end
+
+    # stops all registered devices and remove them from registered list
+    def stop_all!
+      @devices.each(&:stop!)
+    end
+
+    # suspend enabling new trace points
+    # user can still create new Device instances, but they won't be functional
+    def suspend_new!
+      @suspend_new = true
+    end
+
+    # reset everything to clean state and disable all devices
+    def reset!
+      @suspend_new = false
+      stop_all!
+    end
+  end
+end
+

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -1,7 +1,7 @@
 class TappingDevice
   class Payload < Hash
     ATTRS = [
-      :target, :receiver, :method_name, :arguments, :return_value, :filepath, :line_number,
+      :target, :receiver, :method_name, :method_object, :arguments, :return_value, :filepath, :line_number,
       :defined_class, :trace, :tp, :sql
     ]
 
@@ -17,6 +17,20 @@ class TappingDevice
         h[k] = v
       end
       h
+    end
+
+    def passed_at(with_method_head: false)
+      arg_name = arguments.keys.detect { |k| arguments[k] == target }
+      return unless arg_name
+      msg = "Passed as '#{arg_name}' in method ':#{method_name}'"
+      msg += "\n  > #{method_head.strip}" if with_method_head
+      msg += "\n  at #{location}"
+      msg
+    end
+
+    def method_head
+      source_file, source_line = method_object.source_location
+      IO.readlines(source_file)[source_line-1]
     end
 
     def location

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -1,6 +1,9 @@
 class TappingDevice
   class Payload < Hash
-    ATTRS = [:receiver, :method_name, :arguments, :return_value, :filepath, :line_number, :defined_class, :trace, :tp, :sql]
+    ATTRS = [
+      :target, :receiver, :method_name, :arguments, :return_value, :filepath, :line_number,
+      :defined_class, :trace, :tp, :sql
+    ]
 
     ATTRS.each do |attr|
       define_method attr do
@@ -16,8 +19,12 @@ class TappingDevice
       h
     end
 
+    def location
+      "#{filepath}:#{line_number}"
+    end
+
     def method_name_and_location
-      "Method: :#{method_name}, line: #{filepath}:#{line_number}"
+      "Method: :#{method_name}, line: #{location}"
     end
 
     def method_name_and_arguments

--- a/lib/tapping_device/sql_tapping_methods.rb
+++ b/lib/tapping_device/sql_tapping_methods.rb
@@ -13,6 +13,7 @@ class TappingDevice
 
     def tap_sql!(object)
       @call_stack = []
+      @target ||= object
       @trace_point = with_trace_point_on_target(object, event: [:call, :c_call]) do |start_tp|
         ########## Check if the call is worth recording ##########
         filepath, line_number = get_call_location(start_tp, padding: 1) # we need extra padding because of `with_trace_point_on_target`

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -1,19 +1,9 @@
 class TappingDevice
   module Trackable
-    def tap_init!(klass, options = {}, &block)
-      new_device(options, &block).tap_init!(klass)
-    end
-
-    def tap_assoc!(record, options = {}, &block)
-      new_device(options, &block).tap_assoc!(record)
-    end
-
-    def tap_on!(object, options = {}, &block)
-      new_device(options, &block).tap_on!(object)
-    end
-
-    def tap_sql!(object, options = {}, &block)
-      new_device(options, &block).tap_sql!(object)
+    [:tap_on!, :tap_init!, :tap_assoc!, :tap_sql!, :tap_passed!].each do |method|
+      define_method method do |object, options = {}, &block|
+        new_device(options, &block).send(method, object)
+      end
     end
 
     def new_device(options, &block)

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe TappingDevice::Payload do
     expect(subject.arguments).to eq({ name: "Stan", age: 25 })
     expect(subject.keys).to eq(
       [
+        :target,
         :receiver,
         :method_name,
         :arguments,

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 RSpec.describe TappingDevice::Payload do
+  let(:device) { TappingDevice.new }
   subject do
-    device = TappingDevice.new
     device.tap_init!(Student)
     Student.new("Stan", 25)
     device.calls.first
@@ -16,6 +16,7 @@ RSpec.describe TappingDevice::Payload do
         :target,
         :receiver,
         :method_name,
+        :method_object,
         :arguments,
         :return_value,
         :filepath,
@@ -38,5 +39,45 @@ RSpec.describe TappingDevice::Payload do
       expect(subject.method_name_and_arguments).to match("Method: :initialize, argments: {:name=>\"Stan\", :age=>25}")
     end
   end
+  describe "#passed_at" do
+    subject { "Stan" }
+    before do
+      device.tap_passed!(subject)
+    end
 
+    it "returns nil if the payload is not from `tap_passed!`" do
+      new_device = TappingDevice.new
+      new_device.tap_init!(Student)
+      Student.new("Stan", 25)
+
+      expect(new_device.calls.first.passed_at).to eq(nil)
+    end
+
+    it "returns the argument name, method name and location" do
+      Student.new(subject, 25); line = __LINE__
+
+      payload = device.calls.first
+      expect(payload.passed_at).to eq(
+        <<~MSG.chomp
+        Passed as 'name' in method ':initialize'
+          at #{__FILE__}:#{line}
+        MSG
+      )
+    end
+
+    context "with_method_head: true" do
+      it "returns method definition's head as well" do
+        Student.new(subject, 25); line = __LINE__
+
+        payload = device.calls.first
+        expect(payload.passed_at(with_method_head: true)).to eq(
+          <<~MSG.chomp
+          Passed as 'name' in method ':initialize'
+            > def initialize(name, age)
+            at #{__FILE__}:#{line}
+          MSG
+        )
+      end
+    end
+  end
 end

--- a/spec/tapping_device_spec.rb
+++ b/spec/tapping_device_spec.rb
@@ -2,6 +2,37 @@ require "spec_helper"
 require "stoppable_examples"
 
 RSpec.describe TappingDevice do
+  describe "tap_passed!"do
+    let(:device) { described_class.new }
+    subject { :tap_passed! }
+
+    def foo(obj)
+      obj
+    end
+
+    def bar(obj)
+      obj
+    end
+
+    it "records all usages of the object" do
+      s = Student.new("Stan", 18)
+      device.tap_passed!(s)
+
+      foo(s); line_1 = __LINE__
+      s.name
+      bar(s); line_2 = __LINE__
+
+      expect(device.calls.count).to eq(2)
+
+      call = device.calls.first
+      expect(call.method_name).to eq(:foo)
+      expect(call.line_number).to eq(line_1.to_s)
+
+      call = device.calls.second
+      expect(call.method_name).to eq(:bar)
+      expect(call.line_number).to eq(line_2.to_s)
+    end
+  end
   describe "#tap_init!" do
     let(:device) { described_class.new }
     subject { :tap_init! }

--- a/spec/tapping_device_spec.rb
+++ b/spec/tapping_device_spec.rb
@@ -31,10 +31,12 @@ RSpec.describe TappingDevice do
       expect(device.calls.count).to eq(2)
 
       call = device.calls.first
+      expect(call.target).to eq(s)
       expect(call.method_name).to eq(:foo)
       expect(call.line_number).to eq(line_1.to_s)
 
       call = device.calls.second
+      expect(call.target).to eq(s)
       expect(call.method_name).to eq(:bar)
       expect(call.line_number).to eq(line_2.to_s)
     end
@@ -115,6 +117,7 @@ RSpec.describe TappingDevice do
       HighSchoolStudent.new("Stan", 18)
 
       expect(device.calls.count).to eq(1)
+      expect(device.calls.first.target).to eq(HighSchoolStudent)
     end
     it "doesn't track School's initialization" do
       device.tap_init!(Student)

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -3,6 +3,29 @@ require "spec_helper"
 RSpec.describe TappingDevice::Trackable do
   include described_class
 
+  describe "#tap_passed!" do
+    def foo(obj)
+      obj
+    end
+
+    def bar(obj)
+      obj
+    end
+
+    it "records all usages of the object" do
+      count = 0
+      s = Student.new("Stan", 18)
+
+      tap_passed!(s) { count += 1 }
+
+      foo(s)
+      s.name
+      bar(s)
+
+      expect(count).to eq(2)
+    end
+  end
+
   describe "#tap_init!" do
     it "tracks Student's initialization" do
       count = 0


### PR DESCRIPTION
`tap_passed!` allows users to track where the object is used as a method call's argument. One example:

```ruby
s = Student.new("Stan", 18)

tap_passed!(s) do |p|
  puts(p.method_name_and_location)
end

foo(s)
bar(s)
```

prints out

```
Method: :foo, line: /Users/st0012/projects/tapping_device/spec/trackable_spec.rb:23
Method: :bar, line: /Users/st0012/projects/tapping_device/spec/trackable_spec.rb:25
```