### PR TITLE
Support track_as_records option

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,35 @@ initialize @ Student
 
 
 ### Options
-- `with_trace_to: 10` - the number of traces we want to put into `trace`. Default is `nil`, so `trace` would be empty
-- `exclude_by_paths: [/path/]` - an array of call path patterns that we want to skip. This could be very helpful when working on large project like Rails applications.
-- `filter_by_paths: [/path/]` - only contain calls from the specified paths
+#### with_trace_to
+It takes an integer as the number of traces we want to put into `trace`. Default is `nil`, so `trace` would be empty. 
+
+```ruby
+stan = Student.new("Stan", 18)
+tap_on!(stan, with_trace_to: 5)
+
+stan.name
+
+puts(device.calls.first.trace) #=>
+/Users/st0012/projects/tapping_device/spec/tapping_device_spec.rb:287:in `block (4 levels) in <top (required)>'
+/Users/st0012/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.2/lib/rspec/core/example.rb:257:in `instance_exec'
+/Users/st0012/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.2/lib/rspec/core/example.rb:257:in `block in run'
+/Users/st0012/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.2/lib/rspec/core/example.rb:503:in `block in with_around_and_singleton_context_hooks'
+/Users/st0012/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.2/lib/rspec/core/example.rb:460:in `block in with_around_example_hooks'
+/Users/st0012/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.2/lib/rspec/core/hooks.rb:464:in `block in run'
+```
+
+#### track_as_records
+It makes the device to track objects as they are ActiveRecord instances. For example:
+
+```ruby
+tap_on!(@post, track_as_records: true)
+post = Post.find(@post.id) # same record but a different object
+post.title #=> this call will be recorded as well
+```
+
+#### exclude_by_paths
+It takes an array of call path patterns that we want to skip. This could be very helpful when working on large project like Rails applications.
 
 ```ruby
 tap_on!(@post, exclude_by_paths: [/active_record/]).and_print(:method_name_and_location)
@@ -207,6 +233,9 @@ user_id FROM  /PROJECT_PATH/sample/app/views/posts/show.html.erb:10
 to_param FROM  /RUBY_PATH/gems/2.6.0/gems/actionpack-5.2.0/lib/action_dispatch/routing/route_set.rb:236
 ```
 
+#### filter_by_paths
+
+Like `exclude_by_paths`, but work in an opposite way.
 
 ### `#tap_init!`
 
@@ -243,6 +272,8 @@ name FROM /PROJECT_PATH/sample/app/views/posts/show.html.erb:5
 user_id FROM /PROJECT_PATH/sample/app/views/posts/show.html.erb:10
 to_param FROM /RUBY_PATH/gems/2.6.0/gems/actionpack-5.2.0/lib/action_dispatch/routing/route_set.rb:236
 ```
+
+Also check the `track_as_records` option if you want to track `ActiveRecord` records.
 
 ### `tap_passed!`
 

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -103,11 +103,24 @@ class TappingDevice
   end
 
   def get_call_location(tp, padding: 0)
+    caller(get_trace_index(tp) + padding).first.split(":")[0..1]
+  end
+
+  def get_trace_index(tp)
     if tp.event == :c_call
-      caller(C_CALLER_START_POINT + padding)
+      C_CALLER_START_POINT
     else
-      caller(CALLER_START_POINT + padding)
-    end.first.split(":")[0..1]
+      CALLER_START_POINT
+    end
+  end
+
+  def get_traces(tp)
+    if with_trace_to = options[:with_trace_to]
+      trace_index = get_trace_index(tp)
+      caller[trace_index..(trace_index + with_trace_to)]
+    else
+      []
+    end
   end
 
   # this needs to be placed upfront so we can exclude noise before doing more work
@@ -130,7 +143,7 @@ class TappingDevice
       filepath: filepath,
       line_number: line_number,
       defined_class: tp.defined_class,
-      trace: caller[CALLER_START_POINT..(CALLER_START_POINT + options[:with_trace_to])],
+      trace: get_traces(tp),
       tp: tp
     })
   end

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -196,6 +196,7 @@ class TappingDevice
     options[:with_trace_to] ||= 50
     options[:root_device] ||= self
     options[:descendants] ||= []
+    options[:track_as_records] ||= false
     options
   end
 
@@ -207,7 +208,16 @@ class TappingDevice
   end
 
   def is_from_target?(object, tp)
-    object.__id__ == tp.self.__id__
+    comparsion = tp.self
+    is_the_same_record?(object, comparsion) || object.__id__ == comparsion.__id__
+  end
+
+  def is_the_same_record?(target, comparsion)
+    return false unless options[:track_as_records]
+    if target.is_a?(ActiveRecord::Base) && comparsion.is_a?(target.class)
+      primary_key = target.class.primary_key
+      target.send(primary_key) && target.send(primary_key) == comparsion.send(primary_key)
+    end
   end
 
   def record_call!(payload)

--- a/spec/tapping_device_spec.rb
+++ b/spec/tapping_device_spec.rb
@@ -277,6 +277,18 @@ RSpec.describe TappingDevice do
       end
     end
 
+    describe "options - with_trace_to: 5" do
+      it "stores trace until given index" do
+        stan = Student.new("Stan", 18)
+
+        device = described_class.new(with_trace_to: 5)
+        device.tap_on!(stan)
+
+        stan.name
+
+        expect(device.calls.first.trace.length).to eq(6)
+      end
+    end
     describe "options - exclude_by_paths: [/path/]" do
       it "skips calls that matches the pattern" do
         stan = Student.new("Stan", 18)

--- a/spec/tapping_device_spec.rb
+++ b/spec/tapping_device_spec.rb
@@ -213,6 +213,33 @@ RSpec.describe TappingDevice do
       expect(names).to match_array([:alias_name])
     end
 
+    context "when targets are ActiveRecord::Base instances" do
+      context "with track_as_records: true" do
+        it "tracks ActiveRecord::Base instances with their ids" do
+          device = described_class.new(exclude_by_paths: [/gems/], track_as_records: true)
+          post = Post.create!(title: "foo", content: "bar")
+
+          device.tap_on!(post)
+
+          Post.last.title
+
+          expect(device.calls.count).to eq(1)
+        end
+      end
+      context "without track_as_records: true" do
+        it "treats the record like normal objects" do
+          device = described_class.new(exclude_by_paths: [/gems/])
+          post = Post.create!(title: "foo", content: "bar")
+
+          device.tap_on!(post)
+
+          Post.last.title
+
+          expect(device.calls.count).to eq(0)
+        end
+      end
+    end
+
     describe "yield parameters" do
       it "detects correct arguments" do
         stan = Student.new("Stan", 18)


### PR DESCRIPTION
This PR adds `track_as_records` option. If the option is set to `true` and the target is an `ActiveRecord::Base` instance, the device will track objects that have the same primary key.

It also fixes the `with_trace_to` option.

Closes #17 