### PR TITLE
Add tracing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,64 +12,56 @@
 
 ## Table of Content
 - [Introduction](#introduction)
-	- [Track Method Calls](#track-method-calls)
-	- [Track Association Calls](#track-association-calls)
-	- [Track Calls that Generates SQL Queries](#track-calls-that-generates-sql-queries)
+    - [Print Object’s Traces](print-objects-traces)
+    - [Track Calls that Generates SQL Queries](#track-calls-that-generates-sql-queries)
 - [Installation](#installation)
 - [Usages](#usages)
-	- Tapping Methods
-		- [tap_init!](#tap_init)
-		- [tap_on!](#tap_on)
-		- [tap_passed!](#tap_passed)
-		- [tap_assoc!](#tap_assoc)
-		- [tap_sql!](#tap_sql)
-	- [Options](#options)
-	- [Payload](#payload-of-the-call)
-	- [Advance Usages](#advance-usages)
+    - Tracing Helpers
+        - [print_trace](#print_trace)
+        - [print_calls_in_detail](#print_calls_in_detail)
+    - Tapping Methods
+        - [tap_init!](#tap_init)
+        - [tap_on!](#tap_on)
+        - [tap_passed!](#tap_passed)
+        - [tap_assoc!](#tap_assoc)
+        - [tap_sql!](#tap_sql)
+    - [Options](#options)
+    - [Payload](#payload-of-the-call)
+    - [Advance Usages](#advance-usages)
 
 ## Introduction
-`tapping_device` is a gem built on top of Ruby’s `TracePoint` class that allows you to tap method calls of specified objects. The purpose for this gem is to make debugging Rails applications easier.  Here are some sample usages:
+`tapping_device` is a gem built on top of Ruby's `TracePoint` class that allows you to tap method calls of specified objects. The purpose of this gem is to make debugging Rails applications easier.  Here are some sample usages:
 
-### Track Method Calls
+### Print Object’s Traces
+
+Let your objects report to you, so you don’t need to guess how they work!
 
 ```ruby
-class PostsController < ApplicationController
+class OrdersController < ApplicationController
   include TappingDevice::Trackable
 
-  def show
-    @post = Post.find(params[:id])
-    tap_on!(@post).and_print(:method_name_and_location)
+  def create
+    @cart = Cart.find(order_params[:cart_id])
+    print_trace(@cart, exclude_by_paths: [/gems/])
+    @order = OrderCreationService.new.perform(@cart)
   end
-end
-```
-
-And you can see these in log:
-
-```
-name FROM /PROJECT_PATH/sample/app/views/posts/show.html.erb:5
-user_id FROM /PROJECT_PATH/sample/app/views/posts/show.html.erb:10
-to_param FROM /RUBY_PATH/gems/2.6.0/gems/actionpack-5.2.0/lib/action_dispatch/routing/route_set.rb:236
-```
-
-### Track Association Calls
-
-Or you can use `tap_assoc!`. This is very useful for tracking potential n+1 query calls, here’s a sample from my work
-
-```ruby
-tap_assoc!(order).and_print(:method_name_and_location)
 ```
 
 ```
-payments FROM /RUBY_PATH/gems/2.6.0/gems/jsonapi-resources-0.9.10/lib/jsonapi/resource.rb:124
-line_items FROM /MY_PROJECT/app/models/line_item_container_helpers.rb:44
-effective_line_items FROM /MY_PROJECT/app/models/line_item_container_helpers.rb:110
-amending_orders FROM /MY_PROJECT/app/models/order.rb:385
-amends_order FROM /MY_PROJECT/app/models/order.rb:432
+Passed as 'cart' in 'OrderCreationService#perform' at /Users/st0012/projects/tapping_device-demo/app/controllers/orders_controller.rb:10
+Passed as 'cart' in 'OrderCreationService#validate_cart' at /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:8
+Called :reserved_until FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:18
+Called :errors FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:9
+Passed as 'cart' in 'OrderCreationService#apply_discount' at /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:10
+Called :apply_discount FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:24
+……
 ```
+
+(Also see [print_calls_in_detail](#print_calls_in_detail))
 
 ### Track Calls that Generates SQL Queries
 
-`tap_sql!` method helps you track which method calls generate sql queries. This is particularly helpful when tracking calls created from a reused `ActiveRecord::Relation` object.
+`tap_sql!` method helps you track which method calls to generate SQL queries. This is particularly helpful when tracking calls created from a reused `ActiveRecord::Relation` object.
 
 ```ruby
 class PostsController < ApplicationController
@@ -104,10 +96,10 @@ Method: each generated sql: SELECT "posts".* FROM "posts" from /PROJECT_PATH/rai
 Method: count generated sql: SELECT COUNT(*) FROM "posts" WHERE "posts"."user_id" = ? from /PROJECT_PATH/rails-6-sample/app/views/posts/index.html.erb:31
 ```
 
-However, depending on the size of your application, tapping any object could **harm the performance significantly**. **Don’t use this on production**
+However, depending on the size of your application, tapping any object could **harm the performance significantly**. **Don't use this on production**
 
 ## Installation
-Add this line to your application’s Gemfile:
+Add this line to your application's Gemfile:
 
 ```ruby
 gem 'tapping_device', group: :development
@@ -128,6 +120,68 @@ $ gem install tapping_device
 ## Usages
 In order to use `tapping_device`, you need to include `TappingDevice::Trackable` module in where you want to track your code and call the following helpers.
 
+### print_trace
+
+It prints the object's trace. It's like mounting a GPS tracker + a spy camera on your object, so you can inspect your program through the object's eyes.
+
+```ruby
+class OrdersController < ApplicationController
+  include TappingDevice::Trackable
+
+  def create
+    @cart = Cart.find(order_params[:cart_id])
+    print_trace(@cart, exclude_by_paths: [/gems/])
+    @order = OrderCreationService.new.perform(@cart)
+  end
+```
+
+```
+Passed as 'cart' in 'OrderCreationService#perform' at /Users/st0012/projects/tapping_device-demo/app/controllers/orders_controller.rb:10
+Passed as 'cart' in 'OrderCreationService#validate_cart' at /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:8
+Called :reserved_until FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:18
+Called :errors FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:9
+Passed as 'cart' in 'OrderCreationService#apply_discount' at /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:10
+Called :apply_discount FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:24
+……
+```
+
+### print_calls_in_detail
+
+It prints the object's calls in detail (including call location, arguments, and return value). It's useful for observing an object's behavior when debugging.
+
+```ruby
+class OrdersController < ApplicationController
+  include TappingDevice::Trackable
+
+  def create
+    @cart = Cart.find(order_params[:cart_id])
+    service = OrderCreationService.new
+    print_calls_in_detail(service)
+    @order = service.perform(@cart)
+  end
+```
+
+```
+:validate_cart # OrderCreationService
+  <= {:cart=>#<Cart id: 1, total: 10, customer_id: 1, promotion_id: nil, reserved_until: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">}
+  => nil
+  FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:8
+:apply_discount # OrderCreationService
+  <= {:cart=>#<Cart id: 1, total: 5, customer_id: 1, promotion_id: 1, reserved_until: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">, :promotion=>#<Promotion id: 1, amount: 0.5e1, customer_id: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">}
+  => true
+  FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:10
+:create_order # OrderCreationService
+  <= {:cart=>#<Cart id: 1, total: 5, customer_id: 1, promotion_id: 1, reserved_until: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">}
+  => #<Order:0x00007f9ebcb17f08>
+  FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:11
+:perform # OrderCreationService
+  <= {:cart=>#<Cart id: 1, total: 5, customer_id: 1, promotion_id: 1, reserved_until: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">, :promotion=>#<Promotion id: 1, amount: 0.5e1, customer_id: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">}
+  => #<Order:0x00007f9ebcb17f08>
+  FROM /Users/st0012/projects/tapping_device-demo/app/controllers/orders_controller.rb:11
+```
+
+The output's order might look strange. This is because tapping_device needs to wait for the call to return in order to have its return value.
+
 ### tap_init!
 
 `tap_init!(class)` -  tracks a class’ instance initialization
@@ -146,7 +200,7 @@ puts(calls.to_s) #=> [[:initialize, {:name=>"Stan", :age=>18}], [:initialize, {:
 
 ### tap_on!
 
- `tap_on!(object)` - tracks any calls received by the object
+ `tap_on!(object)` - tracks any calls received by the object.
 
 ```ruby
 class PostsController < ApplicationController
@@ -284,7 +338,7 @@ post.title #=> this call will be recorded as well
 ```
 
 #### exclude_by_paths
-It takes an array of call path patterns that we want to skip. This could be very helpful when working on large project like Rails applications.
+It takes an array of call path patterns that we want to skip. This could be very helpful when working on a large project like Rails applications.
 
 ```ruby
 tap_on!(@post, exclude_by_paths: [/active_record/]).and_print(:method_name_and_location)
@@ -306,19 +360,19 @@ to_param FROM  /RUBY_PATH/gems/2.6.0/gems/actionpack-5.2.0/lib/action_dispatch/r
 
 #### filter_by_paths
 
-Like `exclude_by_paths`, but work in an opposite way.
+Like `exclude_by_paths`, but work in the opposite way.
 
 
 ### Payload of The Call
-All tapping methods (start with `tap_`) takes a block and yield a `Payload` object as block argument. It responds to
+All tapping methods (start with `tap_`) takes a block and yield a `Payload` object as a block argument. It responds to
 
 - `target` - the target for `tap_x` call
 - `receiver` - the receiver object
 - `method_name` - method’s name (symbol) 
-	- e.g. `:name`
-- `method_object` - the method object that’s being called. It might be `nil` in some edge cases.
+    - e.g. `:name`
+- `method_object` - the method object that's being called. It might be `nil` in some edge cases.
 - `arguments` - arguments of the method call
-	- e.g. `{name: “Stan”, age: 25}`
+    - e.g. `{name: “Stan”, age: 25}`
 - `return_value` - return value of the method call
 - `filepath` - path to the file that performs the method call
 - `line_number` 
@@ -345,7 +399,7 @@ Passed as 'object' in method ':initialize'
   at /Users/st0012/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/actionview-6.0.0/lib/action_view/helpers/tags/label.rb:60
 ```
 
-You can also set `passed_at(with_method_head: true)` to see the method’s head
+You can also set `passed_at(with_method_head: true)` to see the method's head.
 
 ```
 Passed as 'object' in method ':initialize'
@@ -364,14 +418,14 @@ initialize @ Student
 
 ### Advance Usages
 
-Tapping methods introduced above like `tap_on!` are designed for simple use cases. They’re actually short for
+Tapping methods introduced above like `tap_on!` are designed for simple use cases. They're actually short for
 
 ```ruby
 device = TappingDevice.new { # tapping action }
 device.tap_on!(object)
 ```
 
-And if you want to do some more configurations like stopping them manually or setting stop condition, you must have a `TappingDevie` instance. You can either get them like the above code, or save the return value of `tap_*!` method calls.
+And if you want to do some more configurations like stopping them manually or setting stop condition, you must have a `TappingDevie` instance. You can either get them like the above code or save the return value of `tap_*!` method calls.
 
 #### Stop tapping
 
@@ -389,16 +443,16 @@ end
 
 Each `TappingDevice` instance can have 3 states:
 
-- `Initial` - means the instance is initialized but hasn’t tapped on anything.
-- `Enabled` - means the instance are tapping on something (has called `tap_*` methods).
+- `Initial` - means the instance is initialized but hasn't tapped on anything.
+- `Enabled` - means the instance is tapping on something (has called `tap_*` methods).
 - `Disabled` - means the instance has been disabled. It will no longer receive any call info.
 
-When debugging, we may create many device instances and tap objects in several places. Then it’ll be quite annoying to manage their states. So `TappingDevice` has several class methods that allows you to manage all `TappingDevice` instances:
+When debugging, we may create many device instances and tap objects in several places. Then it'll be quite annoying to manage their states. So `TappingDevice` has several class methods that allows you to manage all `TappingDevice` instances:
 
-- `TappingDevice.devices` - Lists all registered devices with `initial` or `enabled` state. Note that any instance that’s been stopped  will be removed from the list.
+- `TappingDevice.devices` - Lists all registered devices with `initial` or `enabled` state. Note that any instance that's been stopped will be removed from the list.
 - `TappingDevice.stop_all!` - Stops all registered devices and remove them from the `devices` list.
-- `TappingDevice.suspend_new!` - Suspends any device instance from changing their state from `initatial` to `enabled`. Which means any  `tap_*` calls after it will no longer work. 
-- `TappingDevice.reset!` - Cancels `suspend_new` (if called) and stops/removes all created devices. Useful to reset environment between test cases.
+- `TappingDevice.suspend_new!` - Suspends any device instance from changing their state from `initial` to `enabled`. Which means any  `tap_*` calls after it will no longer work. 
+- `TappingDevice.reset!` - Cancels `suspend_new` (if called) and stops/removes all created devices. Useful to reset the environment between test cases.
 
 ## Development
 
@@ -412,8 +466,8 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/st0012
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The gem is available as open-source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
 ## Code of Conduct
 
-Everyone interacting in the TappingDevice project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/tapping_device/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the TappingDevice project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/tapping_device/blob/master/CODE_OF_CONDUCT.md).

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -83,7 +83,7 @@ class TappingDevice
 
   def track(object, condition:)
     @target = object
-    @trace_point = TracePoint.new(:return) do |tp|
+    @trace_point = TracePoint.new(options[:event_type]) do |tp|
       if send(condition, object, tp)
         filepath, line_number = get_call_location(tp)
 
@@ -209,6 +209,7 @@ class TappingDevice
     options[:exclude_by_paths] ||= []
     options[:with_trace_to] ||= 50
     options[:root_device] ||= self
+    options[:event_type] ||= :return
     options[:descendants] ||= []
     options[:track_as_records] ||= false
     options

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -42,12 +42,12 @@ class TappingDevice
       sql: "QUERIES",
       return_value: "=>",
       arguments: "<=",
-      defined_class: "@"
+      defined_class: "#"
     }
 
     SYMBOLS.each do |name, symbol|
       define_method "method_name_and_#{name}" do
-        "#{method_name} #{symbol} #{send(name)}"
+        ":#{method_name} #{symbol} #{send(name)}"
       end
     end
 

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -6,6 +6,18 @@ class TappingDevice
       end
     end
 
+    def print_traces(target)
+      device_1 = tap_on!(target, event_type: :call) do |payload|
+        puts("Called #{payload.method_name_and_location}")
+      end
+      device_2 = tap_passed!(target, event_type: :call) do |payload|
+        arg_name = payload.arguments.keys.detect { |k| payload.arguments[k] == target }
+        next unless arg_name
+        puts("Passed as '#{arg_name}' in '#{payload.defined_class}##{payload.method_name}' at #{payload.location}")
+      end
+      [device_1, device_2]
+    end
+
     def new_device(options, &block)
       TappingDevice.new(options, &block)
     end

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -18,6 +18,10 @@ class TappingDevice
       [device_1, device_2]
     end
 
+    def print_calls_in_detail(target)
+      tap_on!(target).and_print(:detail_call_info)
+    end
+
     def new_device(options, &block)
       TappingDevice.new(options, &block)
     end

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -6,11 +6,13 @@ class TappingDevice
       end
     end
 
-    def print_traces(target)
-      device_1 = tap_on!(target, event_type: :call) do |payload|
+    def print_traces(target, options = {})
+      options[:event_type] = :call
+
+      device_1 = tap_on!(target, options) do |payload|
         puts("Called #{payload.method_name_and_location}")
       end
-      device_2 = tap_passed!(target, event_type: :call) do |payload|
+      device_2 = tap_passed!(target, options) do |payload|
         arg_name = payload.arguments.keys.detect { |k| payload.arguments[k] == target }
         next unless arg_name
         puts("Passed as '#{arg_name}' in '#{payload.defined_class}##{payload.method_name}' at #{payload.location}")
@@ -18,8 +20,8 @@ class TappingDevice
       [device_1, device_2]
     end
 
-    def print_calls_in_detail(target)
-      tap_on!(target).and_print(:detail_call_info)
+    def print_calls_in_detail(target, options = {})
+      tap_on!(target, options).and_print(:detail_call_info)
     end
 
     def new_device(options, &block)

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe TappingDevice::Payload do
     it "returns method_name, arugments, return_value, and filepath" do
       expect(subject.detail_call_info).to match(
        <<~MSG
-       initialize @ Student
+       :initialize # Student
          <= {:name=>"Stan", :age=>25}
          => 25
          FROM #{__FILE__}:7

--- a/spec/tapping_device_spec.rb
+++ b/spec/tapping_device_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe TappingDevice do
 
       expect do
         stan.name
-      end.to output("name <= {}\n").to_stdout
+      end.to output(":name <= {}\n").to_stdout
     end
   end
 

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -37,6 +37,36 @@ RSpec.describe TappingDevice::Trackable do
     end
   end
 
+  describe "#print_calls_in_detail" do
+    include_context "order creation"
+
+    it "prints out target's calls in detail" do
+      cart = Cart.new
+      service = CartOperationService.new
+      print_calls_in_detail(service)
+
+      expect do
+        service.perform(cart)
+      end.to output(/:validate_cart # CartOperationService
+  <= {:cart=>#<Cart:.*>}
+  => #<Cart:.*>
+  FROM #{__FILE__}:.*
+:apply_discount # CartOperationService
+  <= {:cart=>#<Cart:.*>}
+  => #<Cart:.*>
+  FROM #{__FILE__}:.*
+:create_order # CartOperationService
+  <= {:cart=>#<Cart:.*>}
+  => #<Order:.*>
+  FROM #{__FILE__}:.*
+:perform # CartOperationService
+  <= {:cart=>#<Cart:.*>}
+  => #<Order:.*>
+  FROM #{__FILE__}:.*/
+      ).to_stdout
+    end
+  end
+
   describe "#print_traces" do
     include_context "order creation"
 
@@ -47,12 +77,12 @@ RSpec.describe TappingDevice::Trackable do
 
       expect do
         service.perform(cart)
-      end.to output(/Passed as 'cart' in 'CartOperationService#perform' at .+
-Passed as 'cart' in 'CartOperationService#validate_cart' at .+
-Called :total FROM .+
-Passed as 'cart' in 'CartOperationService#apply_discount' at .+
-Called :promotion FROM .+
-Passed as 'cart' in 'CartOperationService#create_order' at .+/
+      end.to output(/Passed as 'cart' in 'CartOperationService#perform' at #{__FILE__}:\d+
+Passed as 'cart' in 'CartOperationService#validate_cart' at #{__FILE__}:\d+
+Called :total FROM #{__FILE__}:\d+
+Passed as 'cart' in 'CartOperationService#apply_discount' at #{__FILE__}:\d+
+Called :promotion FROM #{__FILE__}:\d+
+Passed as 'cart' in 'CartOperationService#create_order' at #{__FILE__}:\d+/
       ).to_stdout
     end
   end

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -3,6 +3,60 @@ require "spec_helper"
 RSpec.describe TappingDevice::Trackable do
   include described_class
 
+  shared_context "order creation" do
+    class Promotion; end
+    class Order;end
+    class Cart
+      def total
+        10
+      end
+      def promotion
+        Promotion.new
+      end
+    end
+    class CartOperationService
+      def perform(cart)
+        validate_cart(cart)
+        apply_discount(cart)
+        create_order(cart)
+      end
+
+      def validate_cart(cart)
+        cart.total
+        cart
+      end
+
+      def apply_discount(cart)
+        cart.promotion
+        cart
+      end
+
+      def create_order(cart)
+        Order.new
+      end
+    end
+  end
+
+  describe "#print_traces" do
+    include_context "order creation"
+
+    it "prints out what the target sees" do
+      cart = Cart.new
+      service = CartOperationService.new
+      print_traces(cart)
+
+      expect do
+        service.perform(cart)
+      end.to output(/Passed as 'cart' in 'CartOperationService#perform' at .+
+Passed as 'cart' in 'CartOperationService#validate_cart' at .+
+Called :total FROM .+
+Passed as 'cart' in 'CartOperationService#apply_discount' at .+
+Called :promotion FROM .+
+Passed as 'cart' in 'CartOperationService#create_order' at .+/
+      ).to_stdout
+    end
+  end
+
   describe "#tap_passed!" do
     def foo(obj)
       obj


### PR DESCRIPTION
Add `print_traces` and `print_calls_in_detail` helpers. 


### print_trace

It prints the object's trace. It's like mounting a GPS tracker + a spy camera on your object, so you can inspect your program through the object's eyes.

```ruby
class OrdersController < ApplicationController
  include TappingDevice::Trackable

  def create
    @cart = Cart.find(order_params[:cart_id])
    print_trace(@cart, exclude_by_paths: [/gems/])
    @order = OrderCreationService.new.perform(@cart)
  end
```

```
Passed as 'cart' in 'OrderCreationService#perform' at /Users/st0012/projects/tapping_device-demo/app/controllers/orders_controller.rb:10
Passed as 'cart' in 'OrderCreationService#validate_cart' at /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:8
Called :reserved_until FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:18
Called :errors FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:9
Passed as 'cart' in 'OrderCreationService#apply_discount' at /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:10
Called :apply_discount FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:24
……
```

### print_calls_in_detail

It prints the object's calls in detail (including call location, arguments, and return value). It's useful for observing an object's behavior when debugging.

```ruby
class OrdersController < ApplicationController
  include TappingDevice::Trackable

  def create
    @cart = Cart.find(order_params[:cart_id])
    service = OrderCreationService.new
    print_calls_in_detail(service)
    @order = service.perform(@cart)
  end
```

```
:validate_cart # OrderCreationService
  <= {:cart=>#<Cart id: 1, total: 10, customer_id: 1, promotion_id: nil, reserved_until: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">}
  => nil
  FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:8
:apply_discount # OrderCreationService
  <= {:cart=>#<Cart id: 1, total: 5, customer_id: 1, promotion_id: 1, reserved_until: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">, :promotion=>#<Promotion id: 1, amount: 0.5e1, customer_id: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">}
  => true
  FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:10
:create_order # OrderCreationService
  <= {:cart=>#<Cart id: 1, total: 5, customer_id: 1, promotion_id: 1, reserved_until: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">}
  => #<Order:0x00007f9ebcb17f08>
  FROM /Users/st0012/projects/tapping_device-demo/app/services/order_creation_service.rb:11
:perform # OrderCreationService
  <= {:cart=>#<Cart id: 1, total: 5, customer_id: 1, promotion_id: 1, reserved_until: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">, :promotion=>#<Promotion id: 1, amount: 0.5e1, customer_id: nil, created_at: "2020-01-05 09:48:28", updated_at: "2020-01-05 09:48:28">}
  => #<Order:0x00007f9ebcb17f08>
  FROM /Users/st0012/projects/tapping_device-demo/app/controllers/orders_controller.rb:11
```

The output's order might look strange. This is because tapping_device needs to wait for the call to return in order to have its return value.
