### PR TITLE
Improve detail_call_info's output format

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install sqlite
       run: |
         # See https://github.community/t5/GitHub-Actions/ubuntu-latest-Apt-repository-list-issues/td-p/41122/page/2
-        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
         sudo apt-get update
         sudo apt-get install libsqlite3-dev
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     tapping_device (0.4.8)
       activerecord (>= 5.2)
+      awesome_print
 
 GEM
   remote: https://rubygems.org/
@@ -18,6 +19,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    awesome_print (1.8.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     database_cleaner (1.7.0)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ Called :apply_discount FROM /Users/st0012/projects/tapping_device-demo/app/servi
 
 It prints the object's calls in detail (including call location, arguments, and return value). It's useful for observing an object's behavior when debugging.
 
+#### Options
+- `awesome_print:` - will print calls in prettier format if set to `true`. Default is `false`
+
 ```ruby
 class OrdersController < ApplicationController
   include TappingDevice::Trackable
@@ -180,7 +183,7 @@ class OrdersController < ApplicationController
   FROM /Users/st0012/projects/tapping_device-demo/app/controllers/orders_controller.rb:11
 ```
 
-The output's order might look strange. This is because tapping_device needs to wait for the call to return in order to have its return value.
+The output's order might look strange. This is because `tapping_device` needs to wait for the call to return in order to have its return value.
 
 ### tap_init!
 

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -1,3 +1,4 @@
+require "awesome_print"
 class TappingDevice
   class Payload < Hash
     ATTRS = [
@@ -38,7 +39,7 @@ class TappingDevice
     end
 
     SYMBOLS = {
-      location: "FROM",
+      location: "from:",
       sql: "QUERIES",
       return_value: "=>",
       arguments: "<=",
@@ -51,12 +52,20 @@ class TappingDevice
       end
     end
 
-    def detail_call_info
+    def detail_call_info(awesome_print: false)
+      arguments_output = arguments.inspect
+      return_value_output = return_value.inspect
+
+      if awesome_print
+        arguments_output = arguments.ai(ruby19_syntax: true, multiline: false)
+        return_value_output = return_value.ai(ruby19_syntax: true, multiline: false)
+      end
+
       <<~MSG
       #{method_name_and_defined_class}
-        <= #{arguments}
-        => #{return_value || "nil"}
-        FROM #{location}
+          from: #{location}
+          <= #{arguments_output}
+          => #{return_value_output}
       MSG
     end
   end

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -21,7 +21,11 @@ class TappingDevice
     end
 
     def print_calls_in_detail(target, options = {})
-      tap_on!(target, options).and_print(:detail_call_info)
+      awesome_print = options.delete(:awesome_print)
+
+      tap_on!(target, options) do |payload|
+        puts(payload.detail_call_info(awesome_print: awesome_print))
+      end
     end
 
     def new_device(options, &block)

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe TappingDevice::Payload do
       expect(subject.detail_call_info).to match(
        <<~MSG
        :initialize # Student
-         <= {:name=>"Stan", :age=>25}
-         => 25
-         FROM #{__FILE__}:7
+           from: #{__FILE__}:7
+           <= {:name=>"Stan", :age=>25}
+           => 25
        MSG
       )
     end
@@ -43,7 +43,7 @@ RSpec.describe TappingDevice::Payload do
 
   describe "#method_name_and_location" do
     it "returns method's name and where it's called" do
-      expect(subject.method_name_and_location).to match(/initialize FROM .+\/tapping_device\/spec\/payload_spec.rb:\d/)
+      expect(subject.method_name_and_location).to match(/initialize from: .+\/tapping_device\/spec\/payload_spec.rb:\d/)
     end
   end
   describe "#method_name_and_arguments" do

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -48,21 +48,21 @@ RSpec.describe TappingDevice::Trackable do
       expect do
         service.perform(cart)
       end.to output(/:validate_cart # CartOperationService
-  <= {:cart=>#<Cart:.*>}
-  => #<Cart:.*>
-  FROM #{__FILE__}:.*
+    from: #{__FILE__}:.*
+    <= {:cart=>#<Cart:.*>}
+    => #<Cart:.*>
 :apply_discount # CartOperationService
-  <= {:cart=>#<Cart:.*>}
-  => #<Cart:.*>
-  FROM #{__FILE__}:.*
+    from: #{__FILE__}:.*
+    <= {:cart=>#<Cart:.*>}
+    => #<Cart:.*>
 :create_order # CartOperationService
-  <= {:cart=>#<Cart:.*>}
-  => #<Order:.*>
-  FROM #{__FILE__}:.*
+    from: #{__FILE__}:.*
+    <= {:cart=>#<Cart:.*>}
+    => #<Order:.*>
 :perform # CartOperationService
-  <= {:cart=>#<Cart:.*>}
-  => #<Order:.*>
-  FROM #{__FILE__}:.*/
+    from: #{__FILE__}:.*
+    <= {:cart=>#<Cart:.*>}
+    => #<Order:.*>/
       ).to_stdout
     end
   end
@@ -79,9 +79,9 @@ RSpec.describe TappingDevice::Trackable do
         service.perform(cart)
       end.to output(/Passed as 'cart' in 'CartOperationService#perform' at #{__FILE__}:\d+
 Passed as 'cart' in 'CartOperationService#validate_cart' at #{__FILE__}:\d+
-Called :total FROM #{__FILE__}:\d+
+Called :total from: #{__FILE__}:\d+
 Passed as 'cart' in 'CartOperationService#apply_discount' at #{__FILE__}:\d+
-Called :promotion FROM #{__FILE__}:\d+
+Called :promotion from: #{__FILE__}:\d+
 Passed as 'cart' in 'CartOperationService#create_order' at #{__FILE__}:\d+/
       ).to_stdout
     end

--- a/tapping_device.gemspec
+++ b/tapping_device.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
     spec.add_dependency "activerecord", ">= 5.2"
   end
 
+  spec.add_dependency "awesome_print"
+
   spec.add_development_dependency "sqlite3", ">= 1.3.6"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
1. Add `awesome_print` option to `print_calls_in_detail` helper. 

```ruby
print_calls_in_detail(ActionDispatch::Http::URL, awesome_print: true)
```

2. Slightly improved payload helpers' output.

## Sample 
<img width="1042" alt="截圖 2020-01-07 下午3 20 07" src="https://user-images.githubusercontent.com/5079556/71876199-32144780-3161-11ea-9597-510e9d82fb25.png">


