### PR TITLE
Fix tap_init!'s payload content

### DIFF
--- a/spec/methods/tap_init_spec.rb
+++ b/spec/methods/tap_init_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe "tap_init!" do
     Student.new("Jane", 23)
 
     expect(device.calls.count).to eq(2)
+    end
+  it "returns the instance object" do
+   device = tap_init!(Student)
+
+   stan = Student.new("Stan", 18)
+
+   expect(device.calls.first.return_value).to eq(stan)
   end
   it "can track subclass's initialization as well" do
     device = tap_init!(HighSchoolStudent)

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -2,14 +2,15 @@ require "spec_helper"
 
 RSpec.describe TappingDevice::Payload do
   let(:device) { TappingDevice.new }
+  let(:stan) { Student.new("Stan", 25) }
   subject do
     device.tap_init!(Student)
-    Student.new("Stan", 25)
+    stan
     device.calls.first
   end
 
   it "supports payload attributes as methods" do
-    expect(subject.receiver).to be_is_a(Student)
+    expect(subject.receiver).to eq(Student)
     expect(subject.arguments).to eq({ name: "Stan", age: 25 })
     expect(subject.keys).to eq(
       [
@@ -33,9 +34,9 @@ RSpec.describe TappingDevice::Payload do
       expect(subject.detail_call_info).to match(
        <<~MSG
        :initialize # Student
-           from: #{__FILE__}:7
+           from: #{__FILE__}:5
            <= {:name=>"Stan", :age=>25}
-           => 25
+           => #{stan.inspect}
        MSG
       )
     end


### PR DESCRIPTION
It used to return the initialized object in `receiver` attribute, which is incorrect. This is due to object initialization in Ruby involves ruby calls and c calls. So we need to manually changing the payload before yielding it.