### PR TITLE
Usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ Let your objects report to you, so you don’t need to guess how they work!
 
 ```ruby
 class OrdersController < ApplicationController
-  include TappingDevice::Trackable
-
   def create
     @cart = Cart.find(order_params[:cart_id])
     print_traces(@cart, exclude_by_paths: [/gems/])
@@ -86,7 +84,6 @@ $ gem install tapping_device
 ```
 
 ## Usages
-In order to use `tapping_device`, you need to include `TappingDevice::Trackable` module in where you want to track your code and call the following helpers.
 
 ### print_traces
 
@@ -94,8 +91,6 @@ It prints the object's trace. It's like mounting a GPS tracker + a spy camera on
 
 ```ruby
 class OrdersController < ApplicationController
-  include TappingDevice::Trackable
-
   def create
     @cart = Cart.find(order_params[:cart_id])
     print_traces(@cart, exclude_by_paths: [/gems/])
@@ -122,8 +117,6 @@ It prints the object's calls in detail (including call location, arguments, and 
 
 ```ruby
 class OrdersController < ApplicationController
-  include TappingDevice::Trackable
-
   def create
     @cart = Cart.find(order_params[:cart_id])
     service = OrderCreationService.new
@@ -175,8 +168,6 @@ puts(calls.to_s) #=> [[:initialize, {:name=>"Stan", :age=>18}], [:initialize, {:
 
 ```ruby
 class PostsController < ApplicationController
-  include TappingDevice::Trackable
-
   before_action :set_post, only: [:show, :edit, :update, :destroy]
 
   def show
@@ -201,7 +192,6 @@ Also check the `track_as_records` option if you want to track `ActiveRecord` rec
 
 ```ruby
 class PostsController < ApplicationController
-  include TappingDevice::Trackable
   # GET /posts/new
   def new
     @post = Post.new

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -66,6 +66,7 @@ class TappingDevice
           from: #{location}
           <= #{arguments_output}
           => #{return_value_output}
+
       MSG
     end
   end

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -33,3 +33,5 @@ class TappingDevice
     end
   end
 end
+
+include TappingDevice::Trackable

--- a/spec/methods/tap_assoc_spec.rb
+++ b/spec/methods/tap_assoc_spec.rb
@@ -3,8 +3,6 @@ require "shared_examples/stoppable_examples"
 require "shared_examples/optionable_examples"
 
 RSpec.describe "tap_assoc!" do
-  include TappingDevice::Trackable
-
   subject { :tap_assoc! }
 
   let(:target) { post }

--- a/spec/methods/tap_init_spec.rb
+++ b/spec/methods/tap_init_spec.rb
@@ -3,8 +3,6 @@ require "shared_examples/stoppable_examples"
 require "shared_examples/optionable_examples"
 
 RSpec.describe "tap_init!" do
-  include TappingDevice::Trackable
-
   subject { :tap_init! }
   let(:target) { Student }
   let(:trigger_action) do

--- a/spec/methods/tap_on_spec.rb
+++ b/spec/methods/tap_on_spec.rb
@@ -3,7 +3,6 @@ require "shared_examples/stoppable_examples"
 require "shared_examples/optionable_examples"
 
 RSpec.describe "tap_on!" do
-  include TappingDevice::Trackable
   let(:subject) { :tap_on! }
 
   it_behaves_like "stoppable" do

--- a/spec/methods/tap_passed_spec.rb
+++ b/spec/methods/tap_passed_spec.rb
@@ -3,8 +3,6 @@ require "shared_examples/stoppable_examples"
 require "shared_examples/optionable_examples"
 
 RSpec.describe "tap_passed!" do
-  include TappingDevice::Trackable
-
   subject { :tap_passed! }
 
   let(:target) { Student.new("Stan", 18) }

--- a/spec/methods/tap_sql_spec.rb
+++ b/spec/methods/tap_sql_spec.rb
@@ -3,8 +3,6 @@ require "shared_examples/stoppable_examples"
 require "shared_examples/optionable_examples"
 
 RSpec.describe "tap_sql!" do
-  include TappingDevice::Trackable
-
   subject { :tap_sql! }
 
   let(:user) { User.create!(name: "Stan") }

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -51,14 +51,17 @@ RSpec.describe TappingDevice::Trackable do
     from: #{__FILE__}:.*
     <= {:cart=>#<Cart:.*>}
     => #<Cart:.*>
+
 :apply_discount # CartOperationService
     from: #{__FILE__}:.*
     <= {:cart=>#<Cart:.*>}
     => #<Cart:.*>
+
 :create_order # CartOperationService
     from: #{__FILE__}:.*
     <= {:cart=>#<Cart:.*>}
     => #<Order:.*>
+
 :perform # CartOperationService
     from: #{__FILE__}:.*
     <= {:cart=>#<Cart:.*>}

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 RSpec.describe TappingDevice::Trackable do
-  include described_class
-
   shared_context "order creation" do
     class Promotion; end
     class Order;end
@@ -276,8 +274,6 @@ Passed as 'cart' in 'CartOperationService#create_order' at #{__FILE__}:\d+/
 end
 
 RSpec.describe TappingDevice::Trackable do
-  include described_class
-
   let!(:post) { Post.create!(title: "foo", content: "bar") }
   let(:locations) { [] }
 


### PR DESCRIPTION
1. Include `TappingDevice::Trackable` by default.
2. Add newlines between call details, so the outputs don't mess together.