### PR TITLE
Add CollectionProxy class

### DIFF
--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -17,7 +17,7 @@ class TappingDevice
       device_2 = tap_passed!(target, options).and_print do |output_payload|
         output_payload.passed_at(inspect: inspect, colorize: colorize)
       end
-      [device_1, device_2]
+      CollectionProxy.new([device_1, device_2])
     end
 
     def print_calls(target, options = {})
@@ -31,6 +31,20 @@ class TappingDevice
 
     def new_device(options, &block)
       TappingDevice.new(options, &block)
+    end
+
+    class CollectionProxy
+      def initialize(devices)
+        @devices = devices
+      end
+
+      [:stop!, :stop_when, :with].each do |method|
+        define_method method do |&block|
+          @devices.each do |device|
+            device.send(method, &block)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -101,6 +101,20 @@ Called :promotion from: #{__FILE__}:\d+
 Passed as :cart in 'CartOperationService#:create_order' at #{__FILE__}:\d+/
       ).to_stdout
     end
+
+    it "works with .with" do
+      print_traces(cart, colorize: false).with do |trace|
+        trace.arguments.keys.include?(:cart)
+      end
+
+      expect do
+        service.perform(cart)
+      end.to output(/Passed as :cart in 'CartOperationService#:perform' at #{__FILE__}:\d+
+Passed as :cart in 'CartOperationService#:validate_cart' at #{__FILE__}:\d+
+Passed as :cart in 'CartOperationService#:apply_discount' at #{__FILE__}:\d+
+Passed as :cart in 'CartOperationService#:create_order' at #{__FILE__}:\d+/
+      ).to_stdout
+    end
   end
 
   describe "#tap_passed!" do


### PR DESCRIPTION
As we're building more helpers, there are cases that we'll need to return multiple device objects from one helper method. In those cases, it'll be hard to do method chaining because the return value would be an Array.

So this commit adds a class called CollectionProxy that holds multiple device instances and passes chained methods to them.