### PR TITLE
Fix tap_init by adding c_* event type

### DIFF
--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -94,7 +94,7 @@ class TappingDevice
   private
 
   def build_minimum_trace_point(event_type:)
-    TracePoint.new(event_type) do |tp|
+    TracePoint.new(*event_type) do |tp|
       next unless filter_condition_satisfied?(tp)
       next if is_tapping_device_call?(tp)
 

--- a/lib/tapping_device/trackers/initialization_tracker.rb
+++ b/lib/tapping_device/trackers/initialization_tracker.rb
@@ -1,6 +1,14 @@
 class TappingDevice
   module Trackers
     class InitializationTracker < TappingDevice
+      def initialize(options = {}, &block)
+        super
+        event_type = @options[:event_type]
+        # if a class doesn't override the 'initialize' method
+        # Class.new will only trigger c_return or c_call
+        @options[:event_type] = [event_type, "c_#{event_type}"]
+      end
+
       def build_payload(tp:, filepath:, line_number:)
         payload = super
         payload[:return_value] = payload[:receiver]

--- a/spec/methods/tap_init_spec.rb
+++ b/spec/methods/tap_init_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe "tap_init!" do
     expect { tap_init!(1) }.to raise_error(TappingDevice::NotAClassError)
   end
 
+  it "tracks class that doesn't define the initialize method (c_call or c_return)" do
+    class Foo; end
+
+    device = tap_init!(Foo)
+
+    Foo.new
+
+    expect(device.calls.count).to eq(1)
+  end
+
   it "tracks Student's initialization" do
     device = tap_init!(Student)
 


### PR DESCRIPTION
If a class doesn't override the `initialize` method, `Class.new` will only trigger `c_return` or `c_call` instead of `return` or `call`.