### PR TITLE
Add print_instance_* and write_instance_* helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ By tracking an object's traces, you'll be able to observe the state changes happ
 - Debug state related issues
 - Debug memoization issues
 
+### Track All Instances Of A Class
+
+It's not always easy to directly access the objects we want to track, especially when they're managed by a library (e.g. `ActiveRecord::Relation`). In such cases, you can use these helpers to track the class's instances:
+
+- `print_instance_calls(ObjectKlass)`
+- `print_instance_traces(ObjectKlass)`
+- `print_instance_mutations(ObjectKlass)`
+- `write_instance_calls(ObjectKlass)`
+- `write_instance_traces(ObjectKlass)`
+- `write_instance_mutations(ObjectKlass)`
+
 
 ### Use `with_HELPER_NAME` for chained method calls
 

--- a/spec/trackable/output_helpers_spec.rb
+++ b/spec/trackable/output_helpers_spec.rb
@@ -76,7 +76,8 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
       end
 
       it "filters output according to the condition" do
-        tap_action.with do |trace|
+        proxy = tap_action
+        proxy.with do |trace|
           trace.arguments.keys.include?(:cart)
         end
 
@@ -176,8 +177,7 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
     end
 
     describe "#print_calls" do
-      let(:helper_method) { "print_calls" }
-      let(:tap_action) { send(helper_method, service, colorize: false) }
+      let(:tap_action) { print_calls(service, colorize: false) }
 
       include_context "order creation"
       it_behaves_like "output calls examples" do
@@ -192,8 +192,7 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
     end
 
     describe "#print_traces" do
-      let(:helper_method) { "print_traces" }
-      let(:tap_action) { send(helper_method, cart, colorize: false) }
+      let(:tap_action) { print_traces(cart, colorize: false) }
 
       include_context "order creation"
       it_behaves_like "output traces examples" do
@@ -209,8 +208,34 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
 
     describe "#print_mutations" do
       let(:student) { Student.new("Stan", 26) }
-      let(:helper_method) { "print_mutations" }
-      let(:tap_action) { send(helper_method, student, colorize: false) }
+      let(:tap_action) { print_mutations(student, colorize: false) }
+
+      it_behaves_like "output mutations examples"
+    end
+  end
+
+  describe "print_instance_* helpers" do
+    def produce_expected_output(expected_output)
+      output(expected_output).to_stdout
+    end
+
+    describe "#print_instance_calls" do
+      let(:tap_action) { print_instance_calls(CartOperationService, colorize: false) }
+
+      include_context "order creation"
+      it_behaves_like "output calls examples"
+    end
+
+    describe "#print_instance_traces" do
+      let(:tap_action) { print_instance_traces(Cart, colorize: false) }
+
+      include_context "order creation"
+      it_behaves_like "output traces examples"
+    end
+
+    describe "#print_instance_mutations" do
+      let(:student) { Student.new("Stan", 26) }
+      let(:tap_action) { print_instance_mutations(Student, colorize: false) }
 
       it_behaves_like "output mutations examples"
     end
@@ -222,8 +247,7 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
     end
 
     describe "#write_calls" do
-      let(:helper_method) { "write_calls" }
-      let(:tap_action) { send(helper_method, service, colorize: false) }
+      let(:tap_action) { write_calls(service, colorize: false) }
 
       include_context "order creation"
       it_behaves_like "output calls examples" do
@@ -238,8 +262,7 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
     end
 
     describe "#write_traces" do
-      let(:helper_method) { "write_traces" }
-      let(:tap_action) { send(helper_method, cart, colorize: false) }
+      let(:tap_action) { write_traces(cart, colorize: false) }
 
       include_context "order creation"
       it_behaves_like "output traces examples" do
@@ -255,8 +278,7 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
 
     describe "#write_mutations" do
       let(:student) { Student.new("Stan", 26) }
-      let(:helper_method) { "write_mutations" }
-      let(:tap_action) { send(helper_method, student, colorize: false) }
+      let(:tap_action) { write_mutations(student, colorize: false) }
 
       it_behaves_like "output mutations examples"
     end
@@ -277,6 +299,35 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
       expect { student.name = "Sean" }.to produce_expected_output(log_file, expected_output)
 
       File.delete(log_file)
+    end
+  end
+
+  describe "write_instance_* helpers" do
+    let(:output_log_file) { "/tmp/tapping_device.log" }
+
+    def produce_expected_output(log_file = output_log_file, expected_output)
+      write_to_file(log_file, expected_output)
+    end
+
+    describe "#write_instance_calls" do
+      let(:tap_action) { write_instance_calls(CartOperationService, colorize: false) }
+
+      include_context "order creation"
+      it_behaves_like "output calls examples"
+    end
+
+    describe "#write_instance_traces" do
+      let(:tap_action) { write_instance_traces(Cart, colorize: false) }
+
+      include_context "order creation"
+      it_behaves_like "output traces examples"
+    end
+
+    describe "#write_instance_mutations" do
+      let(:student) { Student.new("Stan", 26) }
+      let(:tap_action) { write_instance_mutations(Student, colorize: false) }
+
+      it_behaves_like "output mutations examples"
     end
   end
 end


### PR DESCRIPTION
These helpers take a class and apply `print_*` or `write_*` helpers to every instance that is initialized after.
Some examples:

```ruby
print_instance_calls(SomeService)
print_instance_traces(Cart)
write_instance_mutations(Order)
```

This closes https://github.com/st0012/tapping_device/issues/51