### PR TITLE
Add force_recording option for debugging

### DIFF
--- a/spec/shared_examples/optionable_examples.rb
+++ b/spec/shared_examples/optionable_examples.rb
@@ -32,4 +32,13 @@ RSpec.shared_examples "optionable" do
       expect(count).to eq(1)
     end
   end
+  context "with options - force_recording: true" do
+    it "skips all other filtering options" do
+      device = send(subject, target, filter_by_paths: [/lib/], force_recording: true)
+
+      trigger_action.call(target)
+
+      expect(device.calls.count).to be >= 1
+    end
+  end
 end


### PR DESCRIPTION
When debugging tapping_device, it's easy to forget about the configs that have been set and get confused by the result. 

By using the `force_recording` option, it'll temporarily ignore all additional filters added by options or `.with` calls.