### PR TITLE
Add with_* helpers (e.g. with_print_calls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,30 @@ write_calls(object, log_file: "/tmp/another_file")
 ```
 
 
+### Use `with_HELPER` for chained method calls
+
+One thing that really bothers me when debugging is to break method chains from time to time. Let's say I call a service object like this:
+
+```ruby
+SomeService.new(params).perform
+```
+
+In order to debug it, I'll need to break the method chain into
+
+```ruby
+service = SomeService.new(params)
+print_calls(service, options)
+service.perform
+```
+
+That's a 3-line change! Which obviously violates the goal of `tapping_device` - making debugging easier with 1 line of code.
+
+So here's another option, just insert a `with_HELPER_NAME` call in between:
+
+```ruby
+SomeService.new(params).with_print_calls(options).perform
+```
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -22,8 +22,15 @@ class TappingDevice
 
     [:calls, :traces, :mutations].each do |subject|
       [:print, :write].each do |output_action|
-        define_method "#{output_action}_#{subject}" do |target, options = {}|
+        helper_method_name = "#{output_action}_#{subject}"
+
+        define_method helper_method_name do |target, options = {}|
           send("output_#{subject}", target, options, output_action: "and_#{output_action}")
+        end
+
+        define_method "with_#{helper_method_name}" do |options = {}|
+          send(helper_method_name, self, options)
+          self
         end
       end
     end

--- a/spec/trackable/output_helpers_spec.rb
+++ b/spec/trackable/output_helpers_spec.rb
@@ -180,7 +180,15 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
       let(:tap_action) { send(helper_method, service, colorize: false) }
 
       include_context "order creation"
-      it_behaves_like "output calls examples"
+      it_behaves_like "output calls examples" do
+        describe "with_print_calls" do
+          it "prints out calls" do
+            expect do
+              service.with_print_calls(colorize: false).perform(cart)
+            end.to produce_expected_output(expected_output)
+          end
+        end
+      end
     end
 
     describe "#print_traces" do
@@ -188,7 +196,15 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
       let(:tap_action) { send(helper_method, cart, colorize: false) }
 
       include_context "order creation"
-      it_behaves_like "output traces examples"
+      it_behaves_like "output traces examples" do
+        describe "with_print_traces" do
+          it "prints out traces" do
+            expect do
+              service.perform(cart.with_print_traces(colorize: false))
+            end.to produce_expected_output(expected_output)
+          end
+        end
+      end
     end
 
     describe "#print_mutations" do
@@ -210,7 +226,15 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
       let(:tap_action) { send(helper_method, service, colorize: false) }
 
       include_context "order creation"
-      it_behaves_like "output calls examples"
+      it_behaves_like "output calls examples" do
+        describe "with_write_calls" do
+          it "prints out calls" do
+            expect do
+              service.with_write_calls(colorize: false).perform(cart)
+            end.to produce_expected_output(expected_output)
+          end
+        end
+      end
     end
 
     describe "#write_traces" do
@@ -218,7 +242,15 @@ Passed as :cart in 'CartOperationService#:create_order' at .*:\d+/
       let(:tap_action) { send(helper_method, cart, colorize: false) }
 
       include_context "order creation"
-      it_behaves_like "output traces examples"
+      it_behaves_like "output traces examples" do
+        describe "with_write_traces" do
+          it "prints out traces" do
+            expect do
+              service.perform(cart.with_write_traces(colorize: false))
+            end.to produce_expected_output(expected_output)
+          end
+        end
+      end
     end
 
     describe "#write_mutations" do


### PR DESCRIPTION
These helpers allow users to perform tracking without breaking chained
method calls.

```ruby
# doing this
Service.new.with_print_calls(tapping_options).perform

# instead of this
service = Service.new
print_calls(service, tapping_options)
service.perform
```

This closes #52 