### PR TITLE
Better support on private methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,40 @@ The default is `false` because
 2. It's still unclear if this hack safe enough for most applications.
 
 
+#### `ignore_private`
+
+Sometimes we use many private methods to perform trivial operations, like
+
+```ruby
+class Operation
+  def extras
+    dig_attribute("extras")
+  end
+
+  private
+
+  def data
+    @data
+  end
+
+  def dig_attribute(attr)
+    data.dig("attributes", attr) 
+  end
+end
+```
+
+And we may not be interested in those method calls. If that's the case, you can use the `ignore_private` option
+
+```ruby
+operation = Operation.new(params)
+print_calls(operation, ignore_private: true) #=> only prints the `extras` call
+```
+
+#### `only_private`
+
+This option does the opposite of the `ignore_private` option does.
+
+
 ### Global Configuration
 
 If you don't want to pass options every time you use a helper, you can use global configuration to change the default values:
@@ -273,3 +307,4 @@ The gem is available as open-source under the terms of the [MIT License](https:/
 ## Code of Conduct
 
 Everyone interacting in the TappingDevice project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/tapping_device/blob/master/CODE_OF_CONDUCT.md).
+

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -104,6 +104,7 @@ class TappingDevice
         next if is_tapping_device_call?(tp)
         next if should_be_skipped_by_paths?(filepath)
         next unless with_condition_satisfied?(payload)
+        next if payload.is_private_call? && @options[:ignore_private]
       end
 
       yield(payload)
@@ -150,6 +151,7 @@ class TappingDevice
       line_number: line_number,
       defined_class: tp.defined_class,
       trace: get_traces(tp),
+      is_private_call?: tp.defined_class.private_method_defined?(tp.callee_id),
       tp: tp
     })
   end
@@ -206,6 +208,7 @@ class TappingDevice
     options[:event_type] ||= config[:event_type]
     options[:hijack_attr_methods] ||= config[:hijack_attr_methods]
     options[:track_as_records] ||= config[:track_as_records]
+    options[:ignore_private] ||= config[:ignore_private]
     # for debugging the gem more easily
     options[:force_recording] ||= false
 

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -105,6 +105,7 @@ class TappingDevice
         next if should_be_skipped_by_paths?(filepath)
         next unless with_condition_satisfied?(payload)
         next if payload.is_private_call? && @options[:ignore_private]
+        next if !payload.is_private_call? && @options[:only_private]
       end
 
       yield(payload)
@@ -209,6 +210,7 @@ class TappingDevice
     options[:hijack_attr_methods] ||= config[:hijack_attr_methods]
     options[:track_as_records] ||= config[:track_as_records]
     options[:ignore_private] ||= config[:ignore_private]
+    options[:only_private] ||= config[:only_private]
     # for debugging the gem more easily
     options[:force_recording] ||= false
 

--- a/lib/tapping_device/configurable.rb
+++ b/lib/tapping_device/configurable.rb
@@ -12,6 +12,7 @@ class TappingDevice
       event_type: :return,
       hijack_attr_methods: false,
       track_as_records: false,
+      ignore_private: false
     }.merge(TappingDevice::Output::DEFAULT_OPTIONS)
 
     included do

--- a/lib/tapping_device/configurable.rb
+++ b/lib/tapping_device/configurable.rb
@@ -12,7 +12,8 @@ class TappingDevice
       event_type: :return,
       hijack_attr_methods: false,
       track_as_records: false,
-      ignore_private: false
+      ignore_private: false,
+      only_private: false
     }.merge(TappingDevice::Output::DEFAULT_OPTIONS)
 
     included do

--- a/lib/tapping_device/output/payload.rb
+++ b/lib/tapping_device/output/payload.rb
@@ -7,7 +7,11 @@ class TappingDevice
       alias :raw_return_value :return_value
 
       def method_name(options = {})
-        ":#{super(options)}"
+        if is_private_call?
+          ":#{super(options)} (private)"
+        else
+          ":#{super(options)}"
+        end
       end
 
       def arguments(options = {})

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -2,7 +2,7 @@ class TappingDevice
   class Payload < Hash
     ATTRS = [
       :target, :receiver, :method_name, :method_object, :arguments, :return_value, :filepath, :line_number,
-      :defined_class, :trace, :tp, :ivar_changes
+      :defined_class, :trace, :tp, :ivar_changes, :is_private_call?
     ]
 
     ATTRS.each do |attr|

--- a/spec/methods/tap_on_spec.rb
+++ b/spec/methods/tap_on_spec.rb
@@ -88,6 +88,49 @@ RSpec.describe "tap_on!" do
     end
   end
 
+  context "with options[:ignore_private]" do
+    let(:c) do
+      c = Class.new(Student)
+      c.class_eval do
+        def number
+          private_number + 10
+        end
+
+        private
+
+        def private_number
+          10
+        end
+      end
+      c
+    end
+    context "when true" do
+      it "ignores private method calls" do
+        s = c.new("Stan", 18)
+
+        device = tap_on!(s, ignore_private: true)
+
+        s.number
+
+        expect(device.calls.count).to eq(1)
+        expect(device.calls.first.method_name).to eq(:number)
+      end
+    end
+    context "when false (default)" do
+      it "records private method calls" do
+        s = c.new("Stan", 18)
+
+        device = tap_on!(s)
+
+        s.number
+
+        expect(device.calls.count).to eq(2)
+        expect(device.calls.first.method_name).to eq(:private_number)
+        expect(device.calls.last.method_name).to eq(:number)
+      end
+    end
+  end
+
   context "when targets are ActiveRecord::Base instances" do
     context "with track_as_records: true" do
       it "tracks ActiveRecord::Base instances with their ids" do

--- a/spec/methods/tap_on_spec.rb
+++ b/spec/methods/tap_on_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "tap_on!" do
     end
   end
 
-  context "with options[:ignore_private]" do
+  describe "private method options" do
     let(:c) do
       c = Class.new(Student)
       c.class_eval do
@@ -104,29 +104,54 @@ RSpec.describe "tap_on!" do
       end
       c
     end
-    context "when true" do
-      it "ignores private method calls" do
-        s = c.new("Stan", 18)
+    let(:stan) do
+      c.new("Stan", 18)
+    end
 
-        device = tap_on!(s, ignore_private: true)
+    context "with options[:ignore_private]" do
+      context "when true" do
+        it "ignores private method calls" do
+          device = tap_on!(stan, ignore_private: true)
 
-        s.number
+          stan.number
 
-        expect(device.calls.count).to eq(1)
-        expect(device.calls.first.method_name).to eq(:number)
+          expect(device.calls.count).to eq(1)
+          expect(device.calls.first.method_name).to eq(:number)
+        end
+      end
+      context "when false (default)" do
+        it "records private method calls" do
+          device = tap_on!(stan)
+
+          stan.number
+
+          expect(device.calls.count).to eq(2)
+          expect(device.calls.first.method_name).to eq(:private_number)
+          expect(device.calls.last.method_name).to eq(:number)
+        end
       end
     end
-    context "when false (default)" do
-      it "records private method calls" do
-        s = c.new("Stan", 18)
+    context "with options[:only_private]" do
+      context "when true" do
+        it "ignores private method calls" do
+          device = tap_on!(stan, only_private: true)
 
-        device = tap_on!(s)
+          stan.number
 
-        s.number
+          expect(device.calls.count).to eq(1)
+          expect(device.calls.first.method_name).to eq(:private_number)
+        end
+      end
+      context "when false (default)" do
+        it "records private method calls" do
+          device = tap_on!(stan)
 
-        expect(device.calls.count).to eq(2)
-        expect(device.calls.first.method_name).to eq(:private_number)
-        expect(device.calls.last.method_name).to eq(:number)
+          stan.number
+
+          expect(device.calls.count).to eq(2)
+          expect(device.calls.first.method_name).to eq(:private_number)
+          expect(device.calls.last.method_name).to eq(:number)
+        end
       end
     end
   end

--- a/spec/output_payload_spec.rb
+++ b/spec/output_payload_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe TappingDevice::Output::Payload do
 
     it "returns the argument name, method name and location" do
       expect(subject.passed_at(options)).to match(
-        /Passed as :name in 'Student#:initialize' at #{__FILE__}:\d+/
+        /Passed as :name in 'Student#:initialize \(private\)' at #{__FILE__}:\d+/
       )
     end
 
@@ -88,7 +88,7 @@ RSpec.describe TappingDevice::Output::Payload do
 
       it "returns method definition's head as well" do
         expect(subject.passed_at(options)).to match(
-        /Passed as :name in 'Student#:initialize' at #{__FILE__}:\d+
+        /Passed as :name in 'Student#:initialize \(private\)' at #{__FILE__}:\d+
   > def initialize\(name, age\)/
         )
       end

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TappingDevice::Payload do
   it "supports payload attributes as methods" do
     expect(subject.receiver).to eq(Student)
     expect(subject.arguments).to eq({ name: "Stan", age: 25 })
-    expect(subject.keys).to eq(
+    expect(subject.keys).to match_array(
       [
         :target,
         :receiver,
@@ -25,7 +25,8 @@ RSpec.describe TappingDevice::Payload do
         :line_number,
         :defined_class,
         :trace,
-        :tp
+        :tp,
+        :is_private_call?
       ]
     )
   end

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,15 @@
+require "tapping_device"
+require "pry"
+
+
+TracePoint.trace(:raise) do |tp|
+  puts("!!!!!!!!")
+  binding.irb
+  ""
+end
+
+def foo(a)
+  a + 10
+end
+
+foo("a")


### PR DESCRIPTION
1. Support `ignore_private` option - closes #50 
2. Support `only_private` option
3. Mark private methods in output payload