### PR TITLE
Fix init tracker

### DIFF
--- a/lib/tapping_device/trackable.rb
+++ b/lib/tapping_device/trackable.rb
@@ -36,7 +36,7 @@ class TappingDevice
         define_method "#{output_action}_instance_#{subject}" do |target_klass, options = {}|
           collection_proxy = AsyncCollectionProxy.new
 
-          tap_init!(target_klass, options) do |payload|
+          tap_init!(target_klass, options.merge(force_recording: true)) do |payload|
             collection_proxy << send(helper_method_name, payload.return_value, options)
           end
 

--- a/lib/tapping_device/trackers/initialization_tracker.rb
+++ b/lib/tapping_device/trackers/initialization_tracker.rb
@@ -9,6 +9,12 @@ class TappingDevice
         @options[:event_type] = [event_type, "c_#{event_type}"]
       end
 
+      def track(object)
+        super
+        @options[:is_active_record_model] = target.ancestors.include?(ActiveRecord::Base)
+        self
+      end
+
       def build_payload(tp:, filepath:, line_number:)
         payload = super
         payload[:return_value] = payload[:receiver]
@@ -24,7 +30,7 @@ class TappingDevice
         receiver = tp.self
         method_name = tp.callee_id
 
-        if target.ancestors.include?(ActiveRecord::Base)
+        if @options[:is_active_record_model]
           method_name == :new && receiver.is_a?(Class) && receiver.ancestors.include?(target)
         else
           method_name == :initialize && receiver.is_a?(target)

--- a/lib/tapping_device/trackers/initialization_tracker.rb
+++ b/lib/tapping_device/trackers/initialization_tracker.rb
@@ -25,7 +25,7 @@ class TappingDevice
         method_name = tp.callee_id
 
         if target.ancestors.include?(ActiveRecord::Base)
-          method_name == :new && receiver.ancestors.include?(target)
+          method_name == :new && receiver.is_a?(Class) && receiver.ancestors.include?(target)
         else
           method_name == :initialize && receiver.is_a?(target)
         end


### PR DESCRIPTION
This fixes https://github.com/st0012/tapping_device/issues/60

It also fixes the issue that `tap_init!` of `*_instance_*` helpers will be affected by filter option's issue.