### PR TITLE
Add tag option

### DIFF
--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -153,6 +153,7 @@ class TappingDevice
       defined_class: tp.defined_class,
       trace: get_traces(tp),
       is_private_call?: tp.defined_class.private_method_defined?(tp.callee_id),
+      tag: options[:tag],
       tp: tp
     })
   end

--- a/lib/tapping_device/output/payload.rb
+++ b/lib/tapping_device/output/payload.rb
@@ -2,16 +2,18 @@ class TappingDevice
   module Output
     class Payload < Payload
       UNDEFINED = "[undefined]"
+      PRIVATE_MARK = " (private)"
 
       alias :raw_arguments :arguments
       alias :raw_return_value :return_value
 
       def method_name(options = {})
-        if is_private_call?
-          ":#{super(options)} (private)"
-        else
-          ":#{super(options)}"
-        end
+        name = ":#{super(options)}"
+
+        name += " [#{tag}]" if tag
+        name += PRIVATE_MARK if is_private_call?
+
+        name
       end
 
       def arguments(options = {})

--- a/lib/tapping_device/payload.rb
+++ b/lib/tapping_device/payload.rb
@@ -2,7 +2,7 @@ class TappingDevice
   class Payload < Hash
     ATTRS = [
       :target, :receiver, :method_name, :method_object, :arguments, :return_value, :filepath, :line_number,
-      :defined_class, :trace, :tp, :ivar_changes, :is_private_call?
+      :defined_class, :trace, :tag, :tp, :ivar_changes, :is_private_call?
     ]
 
     ATTRS.each do |attr|

--- a/spec/payload_spec.rb
+++ b/spec/payload_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe TappingDevice::Payload do
         :line_number,
         :defined_class,
         :trace,
+        :tag,
         :tp,
         :is_private_call?
       ]

--- a/spec/trackable/output_helpers_spec.rb
+++ b/spec/trackable/output_helpers_spec.rb
@@ -4,6 +4,7 @@ require "contexts/order_creation"
 RSpec.describe TappingDevice::Trackable do
   let(:cart) { Cart.new }
   let(:service) { OrderCreationService.new }
+  let(:options) { { colorize: false } }
 
   shared_examples "output calls examples" do
     let(:expected_output) do
@@ -32,6 +33,37 @@ RSpec.describe TappingDevice::Trackable do
       tap_action
 
       expect { service.perform(cart) }.to produce_expected_output(expected_output)
+    end
+
+    context "with tag: option" do
+      let(:options) { { colorize: false, tag: "service" } }
+      let(:expected_output) do
+/:validate_cart \[service\] # OrderCreationService
+    from: .*:.*
+    <= {cart: #<Cart:.*>}
+    => #<Cart:.*>
+
+:apply_discount \[service\] # OrderCreationService
+    from: .*:.*
+    <= {cart: #<Cart:.*>}
+    => #<Cart:.*>
+
+:create_order \[service\] # OrderCreationService
+    from: .*:.*
+    <= {cart: #<Cart:.*>}
+    => #<Order:.*>
+
+:perform \[service\] # OrderCreationService
+    from: .*:.*
+    <= {cart: #<Cart:.*>}
+    => #<Order:.*>/
+      end
+
+      it "prints out target's calls in detail" do
+        tap_action
+
+        expect { service.perform(cart) }.to produce_expected_output(expected_output)
+      end
     end
 
     context "with '.with' chained" do
@@ -177,7 +209,7 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
     end
 
     describe "#print_calls" do
-      let(:tap_action) { print_calls(service, colorize: false) }
+      let(:tap_action) { print_calls(service, options) }
 
       include_context "order creation"
       it_behaves_like "output calls examples" do
@@ -192,7 +224,7 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
     end
 
     describe "#print_traces" do
-      let(:tap_action) { print_traces(cart, colorize: false) }
+      let(:tap_action) { print_traces(cart, options) }
 
       include_context "order creation"
       it_behaves_like "output traces examples" do
@@ -208,7 +240,7 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
 
     describe "#print_mutations" do
       let(:student) { Student.new("Stan", 26) }
-      let(:tap_action) { print_mutations(student, colorize: false) }
+      let(:tap_action) { print_mutations(student, options) }
 
       it_behaves_like "output mutations examples"
     end
@@ -220,14 +252,14 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
     end
 
     describe "#print_instance_calls" do
-      let(:tap_action) { print_instance_calls(OrderCreationService, colorize: false) }
+      let(:tap_action) { print_instance_calls(OrderCreationService, options) }
 
       include_context "order creation"
       it_behaves_like "output calls examples"
     end
 
     describe "#print_instance_traces" do
-      let(:tap_action) { print_instance_traces(Cart, colorize: false) }
+      let(:tap_action) { print_instance_traces(Cart, options) }
 
       include_context "order creation"
       it_behaves_like "output traces examples"
@@ -235,7 +267,7 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
 
     describe "#print_instance_mutations" do
       let(:student) { Student.new("Stan", 26) }
-      let(:tap_action) { print_instance_mutations(Student, colorize: false) }
+      let(:tap_action) { print_instance_mutations(Student, options) }
 
       it_behaves_like "output mutations examples"
     end
@@ -247,7 +279,7 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
     end
 
     describe "#write_calls" do
-      let(:tap_action) { write_calls(service, colorize: false) }
+      let(:tap_action) { write_calls(service, options) }
 
       include_context "order creation"
       it_behaves_like "output calls examples" do
@@ -262,7 +294,7 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
     end
 
     describe "#write_traces" do
-      let(:tap_action) { write_traces(cart, colorize: false) }
+      let(:tap_action) { write_traces(cart, options) }
 
       include_context "order creation"
       it_behaves_like "output traces examples" do
@@ -278,7 +310,7 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
 
     describe "#write_mutations" do
       let(:student) { Student.new("Stan", 26) }
-      let(:tap_action) { write_mutations(student, colorize: false) }
+      let(:tap_action) { write_mutations(student, options) }
 
       it_behaves_like "output mutations examples"
     end
@@ -294,7 +326,7 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
     changes:
       @name: "Stan" => "Sean"/
 
-      write_mutations(student, log_file: log_file, colorize: false)
+      write_mutations(student, options.merge(log_file: log_file))
 
       expect { student.name = "Sean" }.to produce_expected_output(log_file, expected_output)
 
@@ -310,14 +342,14 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
     end
 
     describe "#write_instance_calls" do
-      let(:tap_action) { write_instance_calls(OrderCreationService, colorize: false) }
+      let(:tap_action) { write_instance_calls(OrderCreationService, options) }
 
       include_context "order creation"
       it_behaves_like "output calls examples"
     end
 
     describe "#write_instance_traces" do
-      let(:tap_action) { write_instance_traces(Cart, colorize: false) }
+      let(:tap_action) { write_instance_traces(Cart, options) }
 
       include_context "order creation"
       it_behaves_like "output traces examples"
@@ -325,7 +357,7 @@ Passed as :cart in 'OrderCreationService#:create_order' at .*:\d+/
 
     describe "#write_instance_mutations" do
       let(:student) { Student.new("Stan", 26) }
-      let(:tap_action) { write_instance_mutations(Student, colorize: false) }
+      let(:tap_action) { write_instance_mutations(Student, options) }
 
       it_behaves_like "output mutations examples"
     end


### PR DESCRIPTION
With the tag option, the printed method calls will be marked with the option's value.

For example, if we have an output of `print_calls(service)` like

```
:validate_cart # OrderCreationService
```

With `print_calls(service, tag: "service")`, it'll be

```
:validate_cart [service] # OrderCreationService
```

This can help distinguish the subject when tracking multiple objects.