### PR TITLE
Replace pry with method_source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ else
 end
 
 gem "activerecord", "~> #{rails_version}"
+gem "pry"

--- a/lib/tapping_device.rb
+++ b/lib/tapping_device.rb
@@ -1,5 +1,5 @@
 require "active_support/core_ext/module/introspection"
-require "pry" # for using Method#source
+require "method_source" # for using Method#source
 
 require "tapping_device/version"
 require "tapping_device/manageable"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require "tapping_device"
 require "tapping_device/trackable"
 require "bundler/setup"
-require "pry"
+# require "pry"
 require "matchers/write_to_file_matcher"
 require 'simplecov'
 

--- a/tapping_device.gemspec
+++ b/tapping_device.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "pry" # for using Method#source in MutationTracker
+  spec.add_dependency "method_source", "~> 1.0.0"
   spec.add_dependency "activesupport"
   spec.add_dependency "pastel"
 


### PR DESCRIPTION
The functionality tapping_device needs actually comes from a gem called `method_source`. So instead of having `pry` as a dependency, we can just require `method_source`.