### PR TITLE
Fix issues with pastel

### DIFF
--- a/lib/tapping_device/output/payload_wrapper.rb
+++ b/lib/tapping_device/output/payload_wrapper.rb
@@ -65,7 +65,7 @@ class TappingDevice
 
         # regenerate attributes with `colorize: true` support
         define_method attribute do |options = {}|
-          call_result = send("original_#{attribute}", options)
+          call_result = send("original_#{attribute}", options).to_s
 
           if options[:colorize]
             PASTEL.send(color, call_result)
@@ -120,7 +120,7 @@ class TappingDevice
           after = generate_string_result(value_changes[:after], options[:inspect])
 
           if options[:colorize]
-            ivar = PASTEL.orange(ivar)
+            ivar = PASTEL.orange(ivar.to_s)
             before = PASTEL.bright_blue(before.to_s)
             after = PASTEL.bright_blue(after.to_s)
           end

--- a/tapping_device.gemspec
+++ b/tapping_device.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "method_source", "~> 1.0.0"
-  spec.add_dependency "pastel"
+  spec.add_dependency "pastel", "~> 0.7"
 end


### PR DESCRIPTION
1. Set a minimum required version of pastel.
2. Make sure we always pass string arguments to pastel methods.